### PR TITLE
iss-hipm-654

### DIFF
--- a/Sources/HipMobileUI/Views/BottomSheetView.cs
+++ b/Sources/HipMobileUI/Views/BottomSheetView.cs
@@ -46,7 +46,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Views
 
             // Bottomsheet
             BottomSheetContentView = new ContentView {BackgroundColor = Color.White};
-            layout.Children.Add (BottomSheetContentView, Constraint.RelativeToParent (parent => parent.X), Constraint.RelativeToParent (parent => parent.Height * 0.9),
+            layout.Children.Add (BottomSheetContentView, Constraint.RelativeToParent (parent => parent.X), Constraint.RelativeToParent (parent => parent.Height * 0.875),
                                  Constraint.RelativeToParent (parent => parent.Width), Constraint.RelativeToParent (parent => parent.Height));
 
             var resources = IoCManager.Resolve<ApplicationResourcesProvider>();
@@ -210,7 +210,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Views
             Rectangle bottomSheetRect = new Rectangle
             {
                 Left = 0,
-                Top = Height * 0.9,
+                Top = Height * 0.875,
                 Size = new Size (Width, Height * 0.1)
             };
             Rectangle buttonRect = new Rectangle

--- a/Sources/HipMobileUI/Views/BottomSheetView.cs
+++ b/Sources/HipMobileUI/Views/BottomSheetView.cs
@@ -211,7 +211,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Views
             {
                 Left = 0,
                 Top = Height - 64,
-                Size = new Size (Width, Height + 64)
+                Size = new Size (Width, 64)
             };
             Rectangle buttonRect = new Rectangle
             {

--- a/Sources/HipMobileUI/Views/BottomSheetView.cs
+++ b/Sources/HipMobileUI/Views/BottomSheetView.cs
@@ -46,7 +46,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Views
 
             // Bottomsheet
             BottomSheetContentView = new ContentView {BackgroundColor = Color.White};
-            layout.Children.Add (BottomSheetContentView, Constraint.RelativeToParent (parent => parent.X), Constraint.RelativeToParent (parent => parent.Height * 0.875),
+            layout.Children.Add (BottomSheetContentView, Constraint.RelativeToParent (parent => parent.X), Constraint.RelativeToParent (parent => parent.Height - 64),
                                  Constraint.RelativeToParent (parent => parent.Width), Constraint.RelativeToParent (parent => parent.Height));
 
             var resources = IoCManager.Resolve<ApplicationResourcesProvider>();
@@ -210,8 +210,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Views
             Rectangle bottomSheetRect = new Rectangle
             {
                 Left = 0,
-                Top = Height * 0.875,
-                Size = new Size (Width, Height * 0.1)
+                Top = Height - 64,
+                Size = new Size (Width, Height + 64)
             };
             Rectangle buttonRect = new Rectangle
             {


### PR DESCRIPTION
Edited height of bottomsheet in order to show 2 lines of the bottomsheet title.

Comment in JIRA:
The recommended number of character limit for the title is 60.
Assuming an iPhone 5S because of a smaller display size.
A word containing only broad-sized characters like 'M', 2 lines of title text contain about 45 characters. Since there are smaller characters like 'i' and whitespace, two lines with typical texts contain more than 60 characters.