### PR TITLE
Iss hipm 738

### DIFF
--- a/Sources/HiPMobile/BusinessLayer/ContentApiFetchers/ExhibitsBaseDataFetcher.cs
+++ b/Sources/HiPMobile/BusinessLayer/ContentApiFetchers/ExhibitsBaseDataFetcher.cs
@@ -188,7 +188,22 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.ContentApiFe
                     {
                         dbExhibit.Pages.First().AppetizerPage.Image = BackupData.BackupImage;
                     }
+
+                    if (exhibitDto.Pages.Count == 1)
+                    {
+                        // Hide downloadbutton since there is nothing to download
+                        dbExhibit.DetailsDataLoaded = true;
+                    }
+                    else
+                    {
+                        dbExhibit.DetailsDataLoaded = false;
+                    }
                 }
+            }
+            else
+            {
+                // Hide downloadbutton since there is nothing to download
+                dbExhibit.DetailsDataLoaded = true;
             }
         }
 

--- a/Sources/HiPMobile/BusinessLayer/ContentApiFetchers/RoutesBaseDataFetcher.cs
+++ b/Sources/HiPMobile/BusinessLayer/ContentApiFetchers/RoutesBaseDataFetcher.cs
@@ -213,18 +213,27 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.ContentApiFe
         {
             var exhibits = ExhibitManager.GetExhibits().ToList();
 
-            foreach (var exhibitId in routeDto.Exhibits)
+            if (routeDto.Exhibits.Count > 0)
             {
-                var dbExhibit = exhibits.SingleOrDefault(x => x.IdForRestApi == exhibitId);
-
-                if (dbExhibit != null)
+                foreach (var exhibitId in routeDto.Exhibits)
                 {
-                    var waypoint = DbManager.CreateBusinessObject<Waypoint>();
-                    waypoint.Exhibit = dbExhibit;
-                    waypoint.Location = dbExhibit.Location;
+                    var dbExhibit = exhibits.SingleOrDefault (x => x.IdForRestApi == exhibitId);
 
-                    dbRoute.Waypoints.Add(waypoint);
+                    if (dbExhibit != null)
+                    {
+                        var waypoint = DbManager.CreateBusinessObject<Waypoint> ();
+                        waypoint.Exhibit = dbExhibit;
+                        waypoint.Location = dbExhibit.Location;
+
+                        dbRoute.Waypoints.Add (waypoint);
+                    }
                 }
+                dbRoute.DetailsDataLoaded = false;
+            }
+            else
+            {
+                // Hide downloadbutton since there is nothing to download
+                dbRoute.DetailsDataLoaded = true;
             }
         }
 

--- a/Sources/HipMobileUI.Droid/Resources/Resource.Designer.cs
+++ b/Sources/HipMobileUI.Droid/Resources/Resource.Designer.cs
@@ -2575,26 +2575,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid
 			// aapt resource value: 0x7f020057
 			public const int avd_hide_password = 2130837591;
 			
-			// aapt resource value: 0x7f020168
-			public const int avd_hide_password_1 = 2130837864;
-			
-			// aapt resource value: 0x7f020169
-			public const int avd_hide_password_2 = 2130837865;
-			
-			// aapt resource value: 0x7f02016a
-			public const int avd_hide_password_3 = 2130837866;
-			
 			// aapt resource value: 0x7f020058
 			public const int avd_show_password = 2130837592;
-			
-			// aapt resource value: 0x7f02016b
-			public const int avd_show_password_1 = 2130837867;
-			
-			// aapt resource value: 0x7f02016c
-			public const int avd_show_password_2 = 2130837868;
-			
-			// aapt resource value: 0x7f02016d
-			public const int avd_show_password_3 = 2130837869;
 			
 			// aapt resource value: 0x7f020059
 			public const int bonuspack_bubble_new = 2130837593;

--- a/Sources/HipMobileUI/ViewModels/Views/RoutesOverviewViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Views/RoutesOverviewViewModel.cs
@@ -63,7 +63,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
 
             var route = selectedRouteItemViewModel.Route;
 
-            if (!route.DetailsDataLoaded)
+            if (!route.DetailsDataLoaded || route.Waypoints.Count == 0)
                 return;
 
             Navigation.PushAsync (new RouteDetailsPageViewModel (route));


### PR DESCRIPTION
Fixed: Empty list of exhibits/pages crashes the app

Please note: In order to test it, you have to change the DatastoreApiPath (ServerEndpoint.cs) to the develop datastore.

The following can be found to check:
- Route "Leere Route" containing no exhibits.
- Exhibit "Leere Sehenswürdigkeit" containing no pages.
- Exhibit "Sehenswürdigkeit als Vorschau" containing an appetizerPage only.