### PR TITLE
Improved responsive dialogue areas on pop-ups

### DIFF
--- a/Sources/HipMobileUI/Views/ExhibitPreviewView.xaml
+++ b/Sources/HipMobileUI/Views/ExhibitPreviewView.xaml
@@ -23,20 +23,24 @@
 
             <StackLayout x:Name="ButtonView" Grid.Row="2" Orientation="Vertical" VerticalOptions="End" Padding="0">
                 <BoxView HeightRequest="1" Color="{StaticResource DarkGrayColor}"/>
-                <StackLayout Orientation="Horizontal" Padding="16,8,8,8" BackgroundColor="{StaticResource LightGrayColor}" VerticalOptions="End">
-                    <Label Text="{helpers:Translate ExhibitOrRouteNearby_Confirm}" FontSize="20" TextColor="{StaticResource AccentColor}"
-                        HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
-                        <Label.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding Confirm}" />
-                        </Label.GestureRecognizers>
-                    </Label>
+                <StackLayout Orientation="Horizontal" Padding="12,0,0,0" BackgroundColor="{StaticResource LightGrayColor}" VerticalOptions="End">
+                    <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
+                        <Label Text="{helpers:Translate ExhibitOrRouteNearby_Confirm}" FontSize="20" TextColor="{StaticResource AccentColor}"
+                            HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
+                        </Label>
+                        <StackLayout.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding Confirm}"/>
+                        </StackLayout.GestureRecognizers>
+                    </StackLayout>
                     <BoxView WidthRequest="2" Color="{StaticResource DarkGrayColor}"/>
-                    <Label Text="{helpers:Translate ExhibitOrRouteNearby_Reject}" FontSize="20" TextColor="{StaticResource AccentColor}"
-                        HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
-                        <Label.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding Decline}" />
-                        </Label.GestureRecognizers>
-                    </Label>
+                    <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
+                        <Label Text="{helpers:Translate ExhibitOrRouteNearby_Reject}" FontSize="20" TextColor="{StaticResource AccentColor}"
+                            HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
+                        </Label>
+                        <StackLayout.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding Decline}"/>
+                        </StackLayout.GestureRecognizers>
+                    </StackLayout>
                 </StackLayout>
             </StackLayout>
         </Grid>

--- a/Sources/HipMobileUI/Views/ExhibitPreviewView.xaml.cs
+++ b/Sources/HipMobileUI/Views/ExhibitPreviewView.xaml.cs
@@ -39,15 +39,19 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Views
                 PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.35, GridUnitType.Star) });
                 PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.15, GridUnitType.Star) });
 
-                PageGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                PageGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(width / 2) });
+                PageGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(width / 2) });
 
                 Grid.SetRow(ImageView, 0);
                 Grid.SetRow(QuestionView, 1);
                 Grid.SetRow(ButtonView, 2);
 
                 Grid.SetColumn(ImageView, 0);
+                Grid.SetColumnSpan (ImageView, 2);
                 Grid.SetColumn(QuestionView, 0);
+                Grid.SetColumnSpan(QuestionView, 2);
                 Grid.SetColumn(ButtonView, 0);
+                Grid.SetColumnSpan(ButtonView, 2);
 
                 QuestionView.Padding = new Thickness(10, 0, 10, 0);
                 ImageView.Aspect = Aspect.AspectFill;
@@ -62,15 +66,19 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Views
                 PageGrid.RowDefinitions.Clear();
                 PageGrid.ColumnDefinitions.Clear();
 
-                PageGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                PageGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(width / 2) });
+                PageGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(width / 2) });
 
                 PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.6, GridUnitType.Star) });
                 PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.2, GridUnitType.Star) });
                 PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.2, GridUnitType.Star) });
 
                 Grid.SetColumn(ImageView, 0);
+                Grid.SetColumnSpan(ImageView, 2);
                 Grid.SetColumn(QuestionView, 0);
+                Grid.SetColumnSpan(QuestionView, 2);
                 Grid.SetColumn(ButtonView, 0);
+                Grid.SetColumnSpan(ButtonView, 2);
 
                 Grid.SetRow(ImageView, 0);
                 Grid.SetRow(QuestionView, 1);

--- a/Sources/HipMobileUI/Views/RoutePreviewView.xaml
+++ b/Sources/HipMobileUI/Views/RoutePreviewView.xaml
@@ -28,20 +28,24 @@
 
             <StackLayout x:Name="ButtonView" Grid.Row="3" Orientation="Vertical" VerticalOptions="End" Padding="0">
                 <BoxView HeightRequest="1" Color="{StaticResource DarkGrayColor}"/>
-                <StackLayout Orientation="Horizontal" Padding="8" BackgroundColor="{StaticResource LightGrayColor}" VerticalOptions="End">
-                    <Label Text="{helpers:Translate ExhibitOrRouteNearby_Confirm}" FontSize="20" TextColor="{StaticResource AccentColor}"
-                        HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
-                        <Label.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding Confirm}" />
-                        </Label.GestureRecognizers>
-                    </Label>
+                <StackLayout Orientation="Horizontal" Padding="12,0,0,0" BackgroundColor="{StaticResource LightGrayColor}" VerticalOptions="End">
+                    <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
+                        <Label Text="{helpers:Translate ExhibitOrRouteNearby_Confirm}" FontSize="20" TextColor="{StaticResource AccentColor}"
+                            HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
+                        </Label>
+                        <StackLayout.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding Confirm}"/>
+                        </StackLayout.GestureRecognizers>
+                    </StackLayout>
                     <BoxView WidthRequest="2" Color="{StaticResource DarkGrayColor}"/>
-                    <Label Text="{helpers:Translate ExhibitOrRouteNearby_Reject}" FontSize="20" TextColor="{StaticResource AccentColor}"
-                        HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
-                        <Label.GestureRecognizers>
-                            <TapGestureRecognizer Command="{Binding Decline}" />
-                        </Label.GestureRecognizers>
-                    </Label>
+                    <StackLayout Orientation="Horizontal" HorizontalOptions="FillAndExpand">
+                        <Label Text="{helpers:Translate ExhibitOrRouteNearby_Reject}" FontSize="20" TextColor="{StaticResource AccentColor}"
+                            HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand">
+                        </Label>
+                        <StackLayout.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding Decline}"/>
+                        </StackLayout.GestureRecognizers>
+                    </StackLayout>
                 </StackLayout>
             </StackLayout>
         </Grid>

--- a/Sources/HipMobileUI/Views/RoutePreviewView.xaml.cs
+++ b/Sources/HipMobileUI/Views/RoutePreviewView.xaml.cs
@@ -36,25 +36,28 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Views
                 PageGrid.RowDefinitions.Clear();
                 PageGrid.ColumnDefinitions.Clear();
 
-                PageGrid.RowDefinitions.Add(new RowDefinition {Height = new GridLength(0.5, GridUnitType.Star)});
-                PageGrid.RowDefinitions.Add(new RowDefinition {Height = new GridLength(0.1, GridUnitType.Star)});
-                PageGrid.RowDefinitions.Add(new RowDefinition {Height = new GridLength(0.25, GridUnitType.Star)});
-                PageGrid.RowDefinitions.Add(new RowDefinition {Height = new GridLength(0.15, GridUnitType.Star)});
+                PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.5, GridUnitType.Star) });
+                PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.1, GridUnitType.Star) });
+                PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.25, GridUnitType.Star) });
+                PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.15, GridUnitType.Star) });
 
-                PageGrid.ColumnDefinitions.Add(new ColumnDefinition {Width = new GridLength(1, GridUnitType.Star)});
+                PageGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(width / 2) });
+                PageGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(width / 2) });
 
                 Grid.SetRow(ImageView, 0);
                 Grid.SetRow(DescriptionView, 1);
                 Grid.SetRow(QuestionView, 2);
                 Grid.SetRow(ButtonView, 3);
-                Grid.SetColumnSpan(ButtonView, 1);
-                Grid.SetColumnSpan(QuestionView, 1);
 
                 Grid.SetColumn(ImageView, 0);
+                Grid.SetColumnSpan(ImageView, 2);
                 Grid.SetColumn(DescriptionView, 0);
+                Grid.SetColumnSpan(DescriptionView, 2);
                 Grid.SetColumn(QuestionView, 0);
+                Grid.SetColumnSpan(QuestionView, 2);
                 Grid.SetColumn(ButtonView, 0);
-                
+                Grid.SetColumnSpan(ButtonView, 2);
+
                 QuestionView.Padding = new Thickness(10,0,10,0);
                 ImageView.Aspect = Aspect.AspectFill;
                 ImageView.Margin = new Thickness(0);
@@ -77,11 +80,13 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Views
                 PageGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.2, GridUnitType.Star) });
 
                 Grid.SetColumn(ImageView, 0);
+                Grid.SetColumnSpan(ImageView, 1);
                 Grid.SetColumn(DescriptionView, 1);
+                Grid.SetColumnSpan(DescriptionView, 1);
                 Grid.SetColumn(QuestionView, 0);
+                Grid.SetColumnSpan(QuestionView, 2);
                 Grid.SetColumn(ButtonView, 0);
                 Grid.SetColumnSpan(ButtonView, 2);
-                Grid.SetColumnSpan(QuestionView, 2);
 
                 Grid.SetRow(ImageView, 0);
                 Grid.SetRow(DescriptionView, 0);


### PR DESCRIPTION
**For the review:**

Activate the GPS and trigger the pop-ups for routes and exhibits nearby. Tap / click left and right of the labels "Ja" and "Nein" to test the reaction of the buttons.
It should also respond if you don't tap directly on the label (Not in extreme cases like the outer border of the button but that's fine).

I already tested the improved tapping areas successfully on iOS, too.