### PR TITLE
Include .gitignore entries for JetBrains Rider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ packages/
 **/CodeGeneration.Log.xml
 !Bindings/CircularRevealBinding/CircularRevealBinding/bin/Debug/CircularRevealBinding.dll
 *.bak
+
+# JetBrains Rider
+*.iml
+.idea


### PR DESCRIPTION
Prevent JetBrains Rider users from accidentally committing local files that should not live in the repo.