### PR TITLE
Iss hipm 704 - Display local notification when passing an exhibit

### DIFF
--- a/Sources/HipMobileUI.Droid/Contracts/DroidAudioPlayer.cs
+++ b/Sources/HipMobileUI.Droid/Contracts/DroidAudioPlayer.cs
@@ -87,7 +87,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid.Contracts
         {
             var mainActivity = (MainActivity) CrossCurrentActivity.Current.Activity;
 
-            NotificationCompat.Builder builder = new NotificationCompat.Builder(mainActivity)
+            var builder = new NotificationCompat.Builder(mainActivity)
                 .SetOngoing(true)
                 .SetSmallIcon(Resource.Drawable.ic_headset_white);
 

--- a/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
+++ b/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
@@ -16,6 +16,7 @@ using System;
 using Android.App;
 using Android.Content;
 using Android.Graphics;
+using Android.Media;
 using Android.OS;
 using Android.Support.V4.App;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer;
@@ -45,15 +46,18 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid.Contracts
         /// <param name="bmpData">Data for the large image</param>
         public void DisplayDefaultNotification(string title, string text, IComparable id = null, byte[] bmpData = null)
         {
-            if (id==null)
+            if (id == null)
                 id = DefaultNotificationId;
 
             var mainActivity = (MainActivity)CrossCurrentActivity.Current.Activity;
 
             var builder = new NotificationCompat.Builder(mainActivity)
+                .SetContentIntent(GenerateReturnToAppIntent(mainActivity))
                 .SetContentTitle(title)
                 .SetContentText(text)
-                .SetSmallIcon(InfoIcon);
+                .SetSmallIcon(InfoIcon)
+                .SetAutoCancel(true)
+                .SetSound(RingtoneManager.GetDefaultUri(RingtoneType.Notification));
             if (bmpData != null)
                 builder.SetLargeIcon(BitmapFactory.DecodeByteArray(bmpData, 0, bmpData.Length));
 
@@ -64,6 +68,12 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid.Contracts
 
             var notificationManager = (NotificationManager)mainActivity.GetSystemService(Context.NotificationService);
             notificationManager.Notify((int)id, builder.Build());
+        }
+
+        private PendingIntent GenerateReturnToAppIntent(Context mainActivity)
+        {
+            var intent = new Intent(mainActivity, typeof(MainActivity));
+            return PendingIntent.GetActivity(mainActivity, 0, intent, PendingIntentFlags.OneShot);
         }
     }
 }

--- a/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
+++ b/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Android.App;
 using Android.Content;
 using Android.Graphics;
@@ -24,17 +25,29 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid.Contracts
 {
     public class DroidNotificationPlayer : INotificationPlayer
     {
-        private const int NotificationId = 06031993;
-        private const int InfoIcon = Resource.Drawable.btn_info;
+        // Use different IDs for different categories of notifications since notifications with the same ID override each other
+        private const int ExhibitNearbyNotificationId = 30052010;
+        private const int DefaultNotificationId = 06031993;
+
+        private const int InfoIcon = Resource.Drawable.info;
+
+        public void DisplayExhibitNearbyNotification(string title, string text, byte[] data = null)
+        {
+            DisplayDefaultNotification(title, text, ExhibitNearbyNotificationId, data);
+        }
 
         /// <summary>
         /// Display a simple notification with an optional large image
         /// </summary>
         /// <param name="title">Heading for the notification</param>
         /// <param name="text">The message below the title</param>
+        /// <param name="id">Unique id for the notification</param>
         /// <param name="bmpData">Data for the large image</param>
-        public void DisplaySimpleNotification(string title, string text, byte[] bmpData)
+        public void DisplayDefaultNotification(string title, string text, IComparable id = null, byte[] bmpData = null)
         {
+            if (id==null)
+                id = DefaultNotificationId;
+
             var mainActivity = (MainActivity)CrossCurrentActivity.Current.Activity;
 
             var builder = new NotificationCompat.Builder(mainActivity)
@@ -50,7 +63,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid.Contracts
             }
 
             var notificationManager = (NotificationManager)mainActivity.GetSystemService(Context.NotificationService);
-            notificationManager.Notify(NotificationId, builder.Build());
+            notificationManager.Notify((int)id, builder.Build());
         }
     }
 }

--- a/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
+++ b/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
@@ -49,10 +49,10 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid.Contracts
             if (id == null)
                 id = DefaultNotificationId;
 
-            var mainActivity = Application.Context.ApplicationContext;
+            var context = Application.Context.ApplicationContext;
 
-            var builder = new NotificationCompat.Builder(mainActivity)
-                .SetContentIntent(GenerateReturnToAppIntent(mainActivity))
+            var builder = new NotificationCompat.Builder(context)
+                .SetContentIntent(GenerateReturnToAppIntent(context))
                 .SetContentTitle(title)
                 .SetContentText(text)
                 .SetSmallIcon(InfoIcon)
@@ -66,7 +66,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid.Contracts
                 builder.SetVisibility((int)NotificationVisibility.Public);
             }
 
-            var notificationManager = (NotificationManager)mainActivity.GetSystemService(Context.NotificationService);
+            var notificationManager = (NotificationManager)context.GetSystemService(Context.NotificationService);
             notificationManager.Notify((int)id, builder.Build());
         }
 

--- a/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
+++ b/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
@@ -49,7 +49,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid.Contracts
             if (id == null)
                 id = DefaultNotificationId;
 
-            var mainActivity = (MainActivity)CrossCurrentActivity.Current.Activity;
+            var mainActivity = Application.Context.ApplicationContext;
 
             var builder = new NotificationCompat.Builder(mainActivity)
                 .SetContentIntent(GenerateReturnToAppIntent(mainActivity))

--- a/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
+++ b/Sources/HipMobileUI.Droid/Contracts/DroidNotificationPlayer.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (C) 2017 History in Paderborn App - Universität Paderborn
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Android.App;
+using Android.Content;
+using Android.Graphics;
+using Android.OS;
+using Android.Support.V4.App;
+using PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer;
+using Plugin.CurrentActivity;
+
+namespace PaderbornUniversity.SILab.Hip.Mobile.Droid.Contracts
+{
+    public class DroidNotificationPlayer : INotificationPlayer
+    {
+        private const int NotificationId = 06031993;
+        private const int InfoIcon = Resource.Drawable.btn_info;
+
+        /// <summary>
+        /// Display a simple notification with an optional large image
+        /// </summary>
+        /// <param name="title">Heading for the notification</param>
+        /// <param name="text">The message below the title</param>
+        /// <param name="bmpData">Data for the large image</param>
+        public void DisplaySimpleNotification(string title, string text, byte[] bmpData)
+        {
+            var mainActivity = (MainActivity)CrossCurrentActivity.Current.Activity;
+
+            var builder = new NotificationCompat.Builder(mainActivity)
+                .SetContentTitle(title)
+                .SetContentText(text)
+                .SetSmallIcon(InfoIcon);
+            if (bmpData != null)
+                builder.SetLargeIcon(BitmapFactory.DecodeByteArray(bmpData, 0, bmpData.Length));
+
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.Lollipop)
+            {
+                builder.SetVisibility((int)NotificationVisibility.Public);
+            }
+
+            var notificationManager = (NotificationManager)mainActivity.GetSystemService(Context.NotificationService);
+            notificationManager.Notify(NotificationId, builder.Build());
+        }
+    }
+}

--- a/Sources/HipMobileUI.Droid/HipMobileUI.Droid.csproj
+++ b/Sources/HipMobileUI.Droid/HipMobileUI.Droid.csproj
@@ -299,6 +299,7 @@
     <Compile Include="Contracts\AndroidImageDimensions.cs" />
     <Compile Include="Contracts\DroidAudioPlayer.cs" />
     <Compile Include="Contracts\DroidNetworkAccessChecker.cs" />
+    <Compile Include="Contracts\DroidNotificationPlayer.cs" />
     <Compile Include="Contracts\DroidStatusBarController.cs" />
     <Compile Include="Contracts\DroidBarsColorsChanger.cs" />
     <Compile Include="Contracts\DroidStorageSizeProvider.cs" />

--- a/Sources/HipMobileUI.Droid/MainActivity.cs
+++ b/Sources/HipMobileUI.Droid/MainActivity.cs
@@ -35,6 +35,7 @@ using Xamarin.Forms;
 using App = PaderbornUniversity.SILab.Hip.Mobile.UI.App;
 using MainPage = PaderbornUniversity.SILab.Hip.Mobile.UI.Pages.MainPage;
 using Acr.UserDialogs;
+using PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer;
 
 namespace PaderbornUniversity.SILab.Hip.Mobile.Droid
 {
@@ -60,6 +61,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Droid
             // init other inversion of control classes
             IoCManager.RegisterInstance(typeof(IFabSizeCalculator), new AndroidFabSizeCalculator());
             IoCManager.RegisterInstance(typeof(IAudioPlayer), new DroidAudioPlayer());
+            IoCManager.RegisterInstance(typeof(INotificationPlayer), new DroidNotificationPlayer());
             IoCManager.RegisterInstance(typeof(IStatusBarController), new DroidStatusBarController());
             IoCManager.RegisterInstance(typeof(ILocationManager), new LocationManager());
             IoCManager.RegisterInstance(typeof(IKeyProvider), new AndroidKeyProvider());

--- a/Sources/HipMobileUI.iOS/Contracts/IosNotificationPlayer.cs
+++ b/Sources/HipMobileUI.iOS/Contracts/IosNotificationPlayer.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Foundation;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer;
 using UIKit;
@@ -21,10 +22,27 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Ios.Contracts
 {
     public class IosNotificationPlayer : INotificationPlayer
     {
-        private const string NotificationId = "exhibitnearby";
+        // Use different IDs for different categories of notifications since notifications with the same ID override each other
+        private const string ExhibitNearbyNotificationId = "exhibitNearbyNotification";
+        private const string DefaultNotificationId = "defaultNotification";
 
-        public void DisplaySimpleNotification(string title, string text, byte[] bmpData)
+        public void DisplayExhibitNearbyNotification(string title, string text, byte[] data = null)
         {
+            DisplayDefaultNotification(title, text, ExhibitNearbyNotificationId, data);
+        }
+
+        /// <summary>
+        /// Display a simple notification with an optional large image
+        /// </summary>
+        /// <param name="title">Heading for the notification</param>
+        /// <param name="text">The message below the title</param>
+        /// <param name="id">Unique id for the notification</param>
+        /// <param name="bmpData">Data for the large image</param>
+        public void DisplayDefaultNotification(string title, string text, IComparable id = null, byte[] bmpData = null)
+        {
+            if (id == null)
+                id = DefaultNotificationId;
+
             UNUserNotificationCenter.Current.GetNotificationSettings(settings =>
             {
                 // Make sure alerts are still allowed
@@ -34,7 +52,6 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Ios.Contracts
                 var content = new UNMutableNotificationContent
                 {
                     Title = title,
-                    Subtitle = "",
                     Body = text
                 };
 
@@ -45,7 +62,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Ios.Contracts
                 }
 
                 var trigger = UNTimeIntervalNotificationTrigger.CreateTrigger(5, false);
-                var request = UNNotificationRequest.FromIdentifier(NotificationId, content, trigger);
+                var request = UNNotificationRequest.FromIdentifier((string)id, content, trigger);
 
                 UNUserNotificationCenter.Current.AddNotificationRequest(request, error =>
                 {

--- a/Sources/HipMobileUI.iOS/Contracts/IosNotificationPlayer.cs
+++ b/Sources/HipMobileUI.iOS/Contracts/IosNotificationPlayer.cs
@@ -52,16 +52,18 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Ios.Contracts
                 var content = new UNMutableNotificationContent
                 {
                     Title = title,
-                    Body = text
+                    Body = text,
+                    Sound = UNNotificationSound.Default
                 };
 
                 if (bmpData != null)
                 {
+                    // Maybe someone can fix this in the future; the image should be displayed along the notification
                     //UIImage image = ConvertDataToImage(bmpData);
                     //content.Attachments = new UNNotificationAttachment[];
                 }
 
-                var trigger = UNTimeIntervalNotificationTrigger.CreateTrigger(5, false);
+                var trigger = UNTimeIntervalNotificationTrigger.CreateTrigger(0, false);
                 var request = UNNotificationRequest.FromIdentifier((string)id, content, trigger);
 
                 UNUserNotificationCenter.Current.AddNotificationRequest(request, error =>

--- a/Sources/HipMobileUI.iOS/Contracts/IosNotificationPlayer.cs
+++ b/Sources/HipMobileUI.iOS/Contracts/IosNotificationPlayer.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (C) 2017 History in Paderborn App - Universität Paderborn
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Foundation;
+using PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer;
+using UIKit;
+using UserNotifications;
+
+namespace PaderbornUniversity.SILab.Hip.Mobile.Ios.Contracts
+{
+    public class IosNotificationPlayer : INotificationPlayer
+    {
+        private const string NotificationId = "exhibitnearby";
+
+        public void DisplaySimpleNotification(string title, string text, byte[] bmpData)
+        {
+            UNUserNotificationCenter.Current.GetNotificationSettings(settings =>
+            {
+                // Make sure alerts are still allowed
+                if (settings.AlertSetting != UNNotificationSetting.Enabled)
+                    return;
+
+                var content = new UNMutableNotificationContent
+                {
+                    Title = title,
+                    Subtitle = "",
+                    Body = text
+                };
+
+                if (bmpData != null)
+                {
+                    //UIImage image = ConvertDataToImage(bmpData);
+                    //content.Attachments = new UNNotificationAttachment[];
+                }
+
+                var trigger = UNTimeIntervalNotificationTrigger.CreateTrigger(5, false);
+                var request = UNNotificationRequest.FromIdentifier(NotificationId, content, trigger);
+
+                UNUserNotificationCenter.Current.AddNotificationRequest(request, error =>
+                {
+                    if (error != null)
+                    {
+                        // TODO: handle error if necessary
+                    }
+                });
+            });
+        }
+
+        private UIImage ConvertDataToImage(byte[] bmpData)
+        {
+            return UIImage.LoadFromData(NSData.FromArray(bmpData));
+        }
+    }
+}

--- a/Sources/HipMobileUI.iOS/HipMobileUI.iOS.csproj
+++ b/Sources/HipMobileUI.iOS/HipMobileUI.iOS.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Contracts\IosBarsColorsChanger.cs" />
     <Compile Include="Contracts\IosImageDimensions.cs" />
     <Compile Include="Contracts\IosNetworkAccessChecker.cs" />
+    <Compile Include="Contracts\IosNotificationPlayer.cs" />
     <Compile Include="Contracts\IosStatusBarController.cs" />
     <Compile Include="Contracts\IosStorageSizeProvider.cs" />
     <Compile Include="CustomRenderers\FloatingActionButtonIosRenderer.cs" />

--- a/Sources/HipMobileUI/App.xaml.cs
+++ b/Sources/HipMobileUI/App.xaml.cs
@@ -57,7 +57,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI
         protected override void OnResume()
         {
             // Handle when your app resumes
-            MessagingCenter.Send<App>(this, AppSharedData.WillWakeUpMessage);
+            MessagingCenter.Send(this, AppSharedData.WillWakeUpMessage);
         }
     }
 }

--- a/Sources/HipMobileUI/HipMobileUI.csproj
+++ b/Sources/HipMobileUI/HipMobileUI.csproj
@@ -59,6 +59,7 @@
     <Compile Include="AudioPlayer\IAudioPlayer.cs" />
     <Compile Include="Container\TabContainerView.cs" />
     <Compile Include="Contracts\IStatusBarController.cs" />
+    <Compile Include="NotificationPlayer\INotificationPlayer.cs" />
     <Compile Include="Controls\CardView.cs" />
     <Compile Include="Controls\CarouselIndicators.cs" />
     <Compile Include="Controls\CustomFontLabel.cs" />
@@ -504,6 +505,7 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/Sources/HipMobileUI/Location/LocationManager.cs
+++ b/Sources/HipMobileUI/Location/LocationManager.cs
@@ -117,7 +117,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
         }
 
         public bool ListeningInBackground { get; private set; }
-        
+
         /// <summary>
         /// Called when the app will go to the background or the screen is locked.
         /// </summary>

--- a/Sources/HipMobileUI/Location/LocationManager.cs
+++ b/Sources/HipMobileUI/Location/LocationManager.cs
@@ -13,12 +13,7 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.Models;
-using PaderbornUniversity.SILab.Hip.Mobile.Shared.Common;
-using PaderbornUniversity.SILab.Hip.Mobile.Shared.Helpers;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Helpers;
-using PaderbornUniversity.SILab.Hip.Mobile.UI.Navigation;
-using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages;
 using Plugin.Geolocator;
 using Plugin.Geolocator.Abstractions;
 using Xamarin.Forms;
@@ -63,14 +58,10 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
         bool IsLocationAvailable();
 
         /// <summary>
-        /// Pauses location updates manually.
+        /// Indicates whether the manager listens to position changes in the background (app minimized)
         /// </summary>
-        void PauseListening();
-
-        /// <summary>
-        /// Starts location updates manually.
-        /// </summary>
-        void StartListening();
+        /// <returns>True if app in background, false otherwise.</returns>
+        bool ListeningInBackground { get; }
     }
 
     public class LocationManager : ILocationManager
@@ -84,7 +75,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
             locator = CrossGeolocator.Current;
             locator.PositionChanged += (sender, args) => { LastKnownLocation = args.Position; };
 
-            // subscribe to events when the app sleeps/wakes up to enable7disable location updates
+            // subscribe to events when the app sleeps/wakes up to enable/disable location updates
             MessagingCenter.Subscribe<App>(this, AppSharedData.WillSleepMessage, WillSleep);
             MessagingCenter.Subscribe<App>(this, AppSharedData.WillWakeUpMessage, WillWakeUp);
         }
@@ -94,7 +85,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
             if (listener != null)
             {
                 // remember the listener and start location updates if necessary
-                bool needToStartLocator = !locator.IsListening && registeredListeners.Count == 0;
+                var needToStartLocator = !locator.IsListening && registeredListeners.Count == 0;
                 registeredListeners.Add(listener);
                 locator.PositionChanged += listener.LocationChanged;
                 if (needToStartLocator)
@@ -125,29 +116,15 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
             return locator.IsGeolocationAvailable;
         }
 
-        public void PauseListening()
-        {
-            if (locator.IsListening)
-            {
-                locator.StopListeningAsync();
-            }
-        }
-
-        public void StartListening()
-        {
-            if (!locator.IsListening)
-            {
-                locator.StartListeningAsync(AppSharedData.MinTimeBwUpdates, AppSharedData.MinDistanceChangeForUpdates);
-            }
-        }
-
+        public bool ListeningInBackground { get; private set; }
+        
         /// <summary>
         /// Called when the app will go to the background or the screen is locked.
         /// </summary>
         /// <param name="obj">The caller.</param>
         private void WillSleep(App obj)
         {
-            PauseListening();
+            ListeningInBackground = true;
         }
 
         /// <summary>
@@ -156,7 +133,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
         /// <param name="obj">The sender of the event.</param>
         private void WillWakeUp(App obj)
         {
-            StartListening();
+            ListeningInBackground = false;
         }
     }
 }

--- a/Sources/HipMobileUI/Location/NearbyExhibitManager.cs
+++ b/Sources/HipMobileUI/Location/NearbyExhibitManager.cs
@@ -84,7 +84,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
                     if (appMinimized)
                     {
                         var notificationPlayer = IoCManager.Resolve<INotificationPlayer>();
-                        notificationPlayer.DisplaySimpleNotification(e.Name, "Es befindet sich eine Sehenswürdigkeit in der Nähe. Geh sie besuchen!", e.Image.Data);
+                        notificationPlayer.DisplayExhibitNearbyNotification(e.Name, "Besuche eine nahe Sehenswürdigkeit!", e.Image.Data);
                     }
                     else
                     {

--- a/Sources/HipMobileUI/Location/NearbyExhibitManager.cs
+++ b/Sources/HipMobileUI/Location/NearbyExhibitManager.cs
@@ -20,10 +20,10 @@ using PaderbornUniversity.SILab.Hip.Mobile.Shared.Common;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Helpers;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Helpers;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Navigation;
-using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.DataAccessLayer;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer;
+using PaderbornUniversity.SILab.Hip.Mobile.UI.Resources;
 
 namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
 {
@@ -52,7 +52,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
 
         public async void CheckNearExhibit(IEnumerable<Exhibit> exhibits, GeoLocation gpsLocation, bool considerTimeouts, bool appMinimized)
         {
-            foreach (Exhibit e in exhibits)
+            foreach (var e in exhibits)
             {
                 var dist = MathUtil.CalculateDistance(e.Location, gpsLocation);
                 if (dist < AppSharedData.ExhibitRadius)
@@ -63,7 +63,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
                     }
                     if (considerTimeouts)
                     {
-                        DateTimeOffset now = DateTimeOffset.Now;
+                        var now = DateTimeOffset.Now;
                         if (e.LastNearbyTime.HasValue)
                         {
                             if (now.Subtract(e.LastNearbyTime.Value) <= dialogTimeout)
@@ -84,11 +84,11 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
                     if (appMinimized)
                     {
                         var notificationPlayer = IoCManager.Resolve<INotificationPlayer>();
-                        notificationPlayer.DisplayExhibitNearbyNotification(e.Name, "Besuche eine nahe Sehenswürdigkeit!", e.Image.Data);
+                        notificationPlayer.DisplayExhibitNearbyNotification(e.Name, Strings.ExhibitNearby_VisitRequest, e.Image.Data);
                     }
                     else
                     {
-                        NavigationViewModel nv = new ExhibitPreviewViewModel(e, this);
+                        var nv = new ExhibitPreviewViewModel(e, this);
                         await
                             IoCManager.Resolve<INavigationService>()
                                       .PushModalAsync(nv);

--- a/Sources/HipMobileUI/Location/NearbyExhibitManager.cs
+++ b/Sources/HipMobileUI/Location/NearbyExhibitManager.cs
@@ -14,19 +14,16 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.Models;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.Managers;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Common;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Helpers;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Helpers;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Navigation;
-using PaderbornUniversity.SILab.Hip.Mobile.UI.Resources;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels;
-using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views;
-using Xamarin.Forms;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.DataAccessLayer;
+using PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer;
 
 namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
 {
@@ -42,17 +39,18 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
         /// <param name="exhibits">The exhibits to check</param>
         /// <param name="gpsLocation">The gps location of the user</param>
         /// <param name="considerTimeouts">Parameter indicating if timeouts for displaying the exhibit nearby message should be taken into account.</param>
-        void CheckNearExhibit(IEnumerable<Exhibit> exhibits, GeoLocation gpsLocation, bool considerTimeouts);
+        /// <param name="appMinimized">True if the method was called while the app is minimized.</param>
+        void CheckNearExhibit(IEnumerable<Exhibit> exhibits, GeoLocation gpsLocation, bool considerTimeouts, bool appMinimized);
 
         void InvokeExhibitVistedEvent(Exhibit exhibit);
     }
 
     public class NearbyExhibitManager : INearbyExhibitManager
     {
-        private readonly TimeSpan dialogTimeout = TimeSpan.FromMinutes(20);
+        private readonly TimeSpan dialogTimeout = TimeSpan.FromMinutes(1);
         public event ExhibitVisitedDelegate ExhibitVisitedEvent;
 
-        public async void CheckNearExhibit(IEnumerable<Exhibit> exhibits, GeoLocation gpsLocation, bool considerTimeouts)
+        public async void CheckNearExhibit(IEnumerable<Exhibit> exhibits, GeoLocation gpsLocation, bool considerTimeouts, bool appMinimized)
         {
             foreach (Exhibit e in exhibits)
             {
@@ -82,10 +80,19 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Location
                         }
                     }
 
-                    NavigationViewModel nv = new ExhibitPreviewViewModel(e, this);
-                    await
-                        IoCManager.Resolve<INavigationService>()
-                                  .PushModalAsync(nv);
+                    // Display popup page or local notification
+                    if (appMinimized)
+                    {
+                        var notificationPlayer = IoCManager.Resolve<INotificationPlayer>();
+                        notificationPlayer.DisplaySimpleNotification(e.Name, "Es befindet sich eine Sehenswürdigkeit in der Nähe. Geh sie besuchen!", e.Image.Data);
+                    }
+                    else
+                    {
+                        NavigationViewModel nv = new ExhibitPreviewViewModel(e, this);
+                        await
+                            IoCManager.Resolve<INavigationService>()
+                                      .PushModalAsync(nv);
+                    }
                 }
             }
         }

--- a/Sources/HipMobileUI/NotificationPlayer/INotificationPlayer.cs
+++ b/Sources/HipMobileUI/NotificationPlayer/INotificationPlayer.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (C) 2017 History in Paderborn App - Universität Paderborn
+//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+namespace PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer
+{
+    public interface INotificationPlayer
+    {
+        /// <summary>
+        /// Displays a simple notification with a custom title, text and image
+        /// </summary>
+        /// <param name="title">Title of the notification</param>
+        /// <param name="text">Text for the notification</param>
+        /// <param name="data">Data of the image (not icon) to be displayed</param>
+        void DisplaySimpleNotification(string title, string text, byte[] data = null);
+    }
+}

--- a/Sources/HipMobileUI/NotificationPlayer/INotificationPlayer.cs
+++ b/Sources/HipMobileUI/NotificationPlayer/INotificationPlayer.cs
@@ -11,16 +11,28 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System;
+
 namespace PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer
 {
     public interface INotificationPlayer
     {
         /// <summary>
-        /// Displays a simple notification with a custom title, text and image
+        /// Displays a notification when in range of an unvisited exhibit
         /// </summary>
         /// <param name="title">Title of the notification</param>
         /// <param name="text">Text for the notification</param>
         /// <param name="data">Data of the image (not icon) to be displayed</param>
-        void DisplaySimpleNotification(string title, string text, byte[] data = null);
+        void DisplayExhibitNearbyNotification(string title, string text, byte[] data = null);
+
+        /// <summary>
+        /// Displays a simple notification with a custom title, text and image
+        /// </summary>
+        /// <param name="title">Title of the notification</param>
+        /// <param name="text">Text for the notification</param>
+        /// <param name="id">The unique id for the notification</param>
+        /// <param name="data">Data of the image (not icon) to be displayed</param>
+        void DisplayDefaultNotification(string title, string text, IComparable id, byte[] data = null);
     }
 }

--- a/Sources/HipMobileUI/Resources/Strings.Designer.cs
+++ b/Sources/HipMobileUI/Resources/Strings.Designer.cs
@@ -341,6 +341,15 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Besuche eine nahe Sehenswürdigkeit!.
+        /// </summary>
+        public static string ExhibitNearby_VisitRequest {
+            get {
+                return ResourceManager.GetString("ExhibitNearby_VisitRequest", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ja.
         /// </summary>
         public static string ExhibitOrRouteNearby_Confirm {

--- a/Sources/HipMobileUI/Resources/Strings.resx
+++ b/Sources/HipMobileUI/Resources/Strings.resx
@@ -814,4 +814,7 @@ Verantwortlich für den Betrieb: Dr. Simon Oberthür</value>
   <data name="ForgotPasswordScreenView_Alert_Unknown_Error_Title" xml:space="preserve">
     <value>Unbekannter Fehler</value>
   </data>
+  <data name="ExhibitNearby_VisitRequest" xml:space="preserve">
+    <value>Besuche eine nahe Sehenswürdigkeit!</value>
+  </data>
 </root>

--- a/Sources/HipMobileUI/ViewModels/Pages/NavigationPageViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Pages/NavigationPageViewModel.cs
@@ -22,7 +22,6 @@ using PaderbornUniversity.SILab.Hip.Mobile.UI.Location;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Navigation;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Resources;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.DataAccessLayer;
-using Realms;
 using Plugin.Geolocator.Abstractions;
 using Xamarin.Forms;
 
@@ -32,8 +31,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
     {
         private ExhibitSet exhibitSet;
         private GeoLocation gpsLocation;
-        private ILocationManager locationManager;
-        private INearbyExhibitManager nearbyExhibitManager;
+        private readonly ILocationManager locationManager;
+        private readonly INearbyExhibitManager nearbyExhibitManager;
         private Route detailsRoute;
 
         private bool showNavigation;
@@ -54,12 +53,12 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
         /// <summary>
         /// Handles the button click
         /// </summary>
-        void FocusGpsClicked()
+        private void FocusGpsClicked()
         {
             MapFocusCommand.Execute(GpsLocation);
         }
 
-        void SkipExhibitClicked()
+        private void SkipExhibitClicked()
         {
             var exhibits = detailsRoute.ActiveSet.Select(waypoint => waypoint.Exhibit);
             SkipExhibitVisited(exhibits);
@@ -102,7 +101,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
         public void LocationChanged(object sender, PositionEventArgs args)
         {
             GpsLocation = args.Position.ToGeoLocation();
-            nearbyExhibitManager.CheckNearExhibit(detailsRoute.ActiveSet.Select(waypoint => waypoint.Exhibit), GpsLocation, false);
+            nearbyExhibitManager.CheckNearExhibit(detailsRoute.ActiveSet.Select(waypoint => waypoint.Exhibit), GpsLocation, false, locationManager.ListeningInBackground);
         }
 
         public override void OnAppearing()
@@ -115,8 +114,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
 
         private void ExhibitVisited(object sender, Exhibit exhibit)
         {
-            Waypoint waypoint = DetailsRoute.Waypoints.First(wp => Equals(wp.Exhibit, exhibit));
-            bool moved = DetailsRoute.MoveToPassiveSet(waypoint);
+            var waypoint = DetailsRoute.Waypoints.First(wp => Equals(wp.Exhibit, exhibit));
+            var moved = DetailsRoute.MoveToPassiveSet(waypoint);
             if (moved)
             {
                 using (IoCManager.Resolve<IDataAccess>().StartTransaction())
@@ -140,20 +139,6 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
             {
                 ExhibitVisited(this, e);
             }
-        }
-
-        public override void OnHidden()
-        {
-            base.OnHidden();
-
-            locationManager.RemoveLocationListener(this);
-        }
-
-        public override void OnRevealed()
-        {
-            base.OnRevealed();
-
-            locationManager.AddLocationListener(this);
         }
 
         public override void OnDisappearing()

--- a/Sources/HipMobileUI/ViewModels/Views/ExhibitsOverviewViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Views/ExhibitsOverviewViewModel.cs
@@ -23,6 +23,7 @@ using PaderbornUniversity.SILab.Hip.Mobile.UI.Helpers;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Location;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Resources;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Helpers;
+using PaderbornUniversity.SILab.Hip.Mobile.UI.NotificationPlayer;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages;
 using Plugin.Geolocator.Abstractions;
 using Xamarin.Forms;
@@ -128,8 +129,6 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
         {
             if (item != null)
             {
-                // Schedule multiple notification to test abstraction
-
                 Navigation.PushAsync(new ExhibitDetailsViewModel(item.Exhibit));
             }
         }

--- a/Sources/HipMobileUI/ViewModels/Views/ExhibitsOverviewViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Views/ExhibitsOverviewViewModel.cs
@@ -21,9 +21,9 @@ using PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.Managers;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Common;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Helpers;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Location;
-using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Resources;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Helpers;
+using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages;
 using Plugin.Geolocator.Abstractions;
 using Xamarin.Forms;
 
@@ -76,9 +76,13 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
         public void LocationChanged(object sender, PositionEventArgs args)
         {
             Position = args.Position;
+
+            if (ExhibitsList == null)
+                return;
+
             SetDistances(args.Position);
 
-            nearbyExhibitManager.CheckNearExhibit(displayedExhibitSet, args.Position.ToGeoLocation(), true);
+            nearbyExhibitManager.CheckNearExhibit(displayedExhibitSet, args.Position.ToGeoLocation(), true, locationManager.ListeningInBackground);
             nearbyRouteManager.CheckNearRoute(RouteManager.GetRoutes(), args.Position.ToGeoLocation());
         }
 
@@ -116,20 +120,6 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
             locationManager.AddLocationListener(this);
         }
 
-        public override void OnHidden()
-        {
-            base.OnHidden();
-
-            locationManager.RemoveLocationListener(this);
-        }
-
-        public override void OnRevealed()
-        {
-            base.OnRevealed();
-
-            locationManager.AddLocationListener(this);
-        }
-
         /// <summary>
         /// Open the exhibitdetails page.
         /// </summary>
@@ -138,6 +128,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
         {
             if (item != null)
             {
+                // Schedule multiple notification to test abstraction
+
                 Navigation.PushAsync(new ExhibitDetailsViewModel(item.Exhibit));
             }
         }
@@ -211,10 +203,10 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
 
             if (newDataCenter.IsNewDataAvailabe())
             {
-                bool downloadData = false;
+                var downloadData = false;
                 if (!Settings.AlwaysDownloadData)
                 {
-                    string result = await Navigation.DisplayActionSheet(Strings.DownloadData_Title,
+                    var result = await Navigation.DisplayActionSheet(Strings.DownloadData_Title,
                                                                         null, null, Strings.DownloadData_Accept, Strings.DownloadData_Cancel, Strings.DownloadData_Always);
 
                     if (result == Strings.DownloadData_Always)

--- a/Sources/HipMobileUI/ViewModels/Views/ExhibitsOverviewViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Views/ExhibitsOverviewViewModel.cs
@@ -47,7 +47,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
             {
                 DisplayedExhibitSet = set;
                 ExhibitsList = new ObservableCollection<ExhibitsOverviewListItemViewModel>();
-                foreach (Exhibit exhibit in set)
+                foreach (var exhibit in set)
                 {
                     var listItem = new ExhibitsOverviewListItemViewModel(exhibit);
                     ExhibitsList.Add(listItem);
@@ -186,7 +186,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
             var set = ExhibitManager.GetExhibitSets().Single();
             DisplayedExhibitSet = set;
             ExhibitsList = new ObservableCollection<ExhibitsOverviewListItemViewModel>();
-            foreach (Exhibit exhibit in set)
+            foreach (var exhibit in set)
             {
                 var listItem = new ExhibitsOverviewListItemViewModel(exhibit);
                 ExhibitsList.Add(listItem);

--- a/Sources/HipMobileUI/ViewModels/Views/RoutePreviewViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Views/RoutePreviewViewModel.cs
@@ -37,7 +37,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
 
         void Accept()
         {
-            IoCManager.Resolve<INavigationService>().ClearModalStack();
+            Navigation.ClearModalStack();
             NearbyRouteManager.OpenRouteDetailsView(RouteId);
         }
 


### PR DESCRIPTION
**FOR TESTING**: Minimize the app and use the GPS (simulator) to move in range of an exhibit. A popup should be displayed containing basic information about the exhibit. A click on the notification opens the app again.

_Due to weird behaviour of the iOS simulator when using GPS and minimized mode the exact functionality is not tested on iOS but should work based on similar tests._

_There is no image displayed on iOS because I was not able to add the image data to the attachment of the notification._