### PR TITLE
Fixed IOC Container Initialization for Individual Unit Tests

### DIFF
--- a/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/MediaToImageConverterTest.cs
+++ b/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/MediaToImageConverterTest.cs
@@ -30,10 +30,10 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileTests.BusinessLayer.DtoT
         [TestFixtureSetUp]
         public void Init ()
         {
-            IoCManager.Clear ();
-            IoCManager.RegisterInstance (typeof (IImageDimension), Substitute.For<IImageDimension> ());
-            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
-        }
+            IoCManager.Clear();
+            IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
+            IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
+            }
 
         [Test, Category("UnitTest")]
         public void Convert_MediaToImageTest()

--- a/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/MediaToImageConverterTest.cs
+++ b/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/MediaToImageConverterTest.cs
@@ -29,10 +29,11 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileTests.BusinessLayer.DtoT
     {
         [TestFixtureSetUp]
         public void Init ()
-            {
+        {
+            IoCManager.Clear ();
             IoCManager.RegisterInstance (typeof (IImageDimension), Substitute.For<IImageDimension> ());
             IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
-            }
+        }
 
         [Test, Category("UnitTest")]
         public void Convert_MediaToImageTest()

--- a/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/MediaToImageConverterTest.cs
+++ b/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/MediaToImageConverterTest.cs
@@ -28,10 +28,11 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileTests.BusinessLayer.DtoT
     public class MediaToImageConverterTest
     {
         [TestFixtureSetUp]
-        public void Init()
-        {
-            IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
-        }
+        public void Init ()
+            {
+            IoCManager.RegisterInstance (typeof (IImageDimension), Substitute.For<IImageDimension> ());
+            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
+            }
 
         [Test, Category("UnitTest")]
         public void Convert_MediaToImageTest()

--- a/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/MediaToImageConverterTest.cs
+++ b/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/MediaToImageConverterTest.cs
@@ -28,12 +28,12 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileTests.BusinessLayer.DtoT
     public class MediaToImageConverterTest
     {
         [TestFixtureSetUp]
-        public void Init ()
+        public void Init()
         {
             IoCManager.Clear();
             IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
             IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
-            }
+        }
 
         [Test, Category("UnitTest")]
         public void Convert_MediaToImageTest()

--- a/Sources/HipMobileUI.Tests/ViewModels/Pages/ExhibitDetailsViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Pages/ExhibitDetailsViewModelTest.cs
@@ -38,6 +38,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Pages
         public void Init()
         {
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
+            IoCManager.RegisterInstance (typeof(IMediaFileManager),Substitute.For <IMediaFileManager>());
             IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
             IoCManager.RegisterInstance(typeof(IAudioPlayer), Substitute.For<IAudioPlayer>());
             IoCManager.RegisterInstance(typeof(IDbChangedHandler), Substitute.For<IDbChangedHandler>());

--- a/Sources/HipMobileUI.Tests/ViewModels/Pages/ExhibitDetailsViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Pages/ExhibitDetailsViewModelTest.cs
@@ -37,8 +37,9 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Pages
         [TestFixtureSetUp]
         public void Init()
         {
+            IoCManager.Clear();
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
-            IoCManager.RegisterInstance (typeof(IMediaFileManager),Substitute.For <IMediaFileManager>());
+            IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
             IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
             IoCManager.RegisterInstance(typeof(IAudioPlayer), Substitute.For<IAudioPlayer>());
             IoCManager.RegisterInstance(typeof(IDbChangedHandler), Substitute.For<IDbChangedHandler>());

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/ImageViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/ImageViewModelTest.cs
@@ -32,7 +32,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
             IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
             IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
-            }
+        }
 
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/ImageViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/ImageViewModelTest.cs
@@ -31,8 +31,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         {
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
             IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
-            IoCManager.RegisterInstance (typeof(IMediaFileManager),Substitute.For<IMediaFileManager>());
-        }
+            IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
+            }
 
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/ImageViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/ImageViewModelTest.cs
@@ -31,6 +31,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         {
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
             IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
+            IoCManager.RegisterInstance (typeof(IMediaFileManager),Substitute.For<IMediaFileManager>());
         }
 
         [Test, Category("UnitTest")]

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/TimeSliderViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/TimeSliderViewModelTest.cs
@@ -32,8 +32,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         {
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
             IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
-            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
-        }
+            IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
+            }
 
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/TimeSliderViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/TimeSliderViewModelTest.cs
@@ -32,6 +32,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         {
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
             IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
+            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
         }
 
         [Test, Category("UnitTest")]

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/TimeSliderViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitDetails/TimeSliderViewModelTest.cs
@@ -33,7 +33,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
             IoCManager.RegisterInstance(typeof(IImageDimension), Substitute.For<IImageDimension>());
             IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
-            }
+        }
 
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewListItemViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewListItemViewModelTest.cs
@@ -18,12 +18,20 @@ using NSubstitute;
 using NUnit.Framework;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Common;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Common.Contracts;
+using PaderbornUniversity.SILab.Hip.Mobile.UI.Navigation;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views;
 
 namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
 {
     class ExhibitsOverviewListItemViewModelTest
     {
+        [TestFixtureSetUp]
+        public void Init ()
+        {
+            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
+            IoCManager.RegisterInstance (typeof (INavigationService), Substitute.For<INavigationService> ());
+        }
+
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()
         {

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewListItemViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewListItemViewModelTest.cs
@@ -28,9 +28,9 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         [TestFixtureSetUp]
         public void Init ()
         {
-            IoCManager.Clear ();
-            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
-            IoCManager.RegisterInstance (typeof (INavigationService), Substitute.For<INavigationService> ());
+            IoCManager.Clear();
+            IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
+            IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
         }
 
         [Test, Category("UnitTest")]

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewListItemViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewListItemViewModelTest.cs
@@ -26,7 +26,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
     class ExhibitsOverviewListItemViewModelTest
     {
         [TestFixtureSetUp]
-        public void Init ()
+        public void Init()
         {
             IoCManager.Clear();
             IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewListItemViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewListItemViewModelTest.cs
@@ -28,6 +28,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         [TestFixtureSetUp]
         public void Init ()
         {
+            IoCManager.Clear ();
             IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
             IoCManager.RegisterInstance (typeof (INavigationService), Substitute.For<INavigationService> ());
         }

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewViewModelTest.cs
@@ -45,6 +45,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
             IoCManager.RegisterInstance(typeof(INearbyExhibitManager), Substitute.For<INearbyExhibitManager>());
             IoCManager.RegisterInstance(typeof(INearbyRouteManager), Substitute.For<INearbyRouteManager>());
             IoCManager.RegisterInstance(typeof(IDbChangedHandler), Substitute.For<IDbChangedHandler>());
+            IoCManager.RegisterInstance (typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
         }
 
         [Test, Category("UnitTest")]

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewViewModelTest.cs
@@ -45,8 +45,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
             IoCManager.RegisterInstance(typeof(INearbyExhibitManager), Substitute.For<INearbyExhibitManager>());
             IoCManager.RegisterInstance(typeof(INearbyRouteManager), Substitute.For<INearbyRouteManager>());
             IoCManager.RegisterInstance(typeof(IDbChangedHandler), Substitute.For<IDbChangedHandler>());
-            IoCManager.RegisterInstance (typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
-        }
+            IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
+            }
 
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/ExhibitsOverviewViewModelTest.cs
@@ -46,7 +46,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
             IoCManager.RegisterInstance(typeof(INearbyRouteManager), Substitute.For<INearbyRouteManager>());
             IoCManager.RegisterInstance(typeof(IDbChangedHandler), Substitute.For<IDbChangedHandler>());
             IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
-            }
+        }
 
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewListItemViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewListItemViewModelTest.cs
@@ -18,6 +18,7 @@ using NSubstitute;
 using NUnit.Framework;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Common;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Common.Contracts;
+using PaderbornUniversity.SILab.Hip.Mobile.UI.Navigation;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views;
 
 namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
@@ -25,6 +26,13 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
     [TestFixture]
     public class RoutesOverviewListItemViewModelTest
     {
+        [TestFixtureSetUp]
+        public void Init ()
+        {
+            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
+            IoCManager.RegisterInstance (typeof (INavigationService), Substitute.For<INavigationService> ());
+        }
+
         [Test, Category("UnitTest")]
         public void GetRouteDistanceText_FormatedText()
         {

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewListItemViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewListItemViewModelTest.cs
@@ -27,12 +27,12 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
     public class RoutesOverviewListItemViewModelTest
     {
         [TestFixtureSetUp]
-        public void Init ()
+        public void Init()
         {
             IoCManager.Clear();
             IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
-            }
+        }
 
         [Test, Category("UnitTest")]
         public void GetRouteDistanceText_FormatedText()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewListItemViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewListItemViewModelTest.cs
@@ -29,10 +29,10 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         [TestFixtureSetUp]
         public void Init ()
         {
-            IoCManager.Clear ();
-            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
-            IoCManager.RegisterInstance (typeof (INavigationService), Substitute.For<INavigationService> ());
-        }
+            IoCManager.Clear();
+            IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
+            IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
+            }
 
         [Test, Category("UnitTest")]
         public void GetRouteDistanceText_FormatedText()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewListItemViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewListItemViewModelTest.cs
@@ -29,6 +29,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         [TestFixtureSetUp]
         public void Init ()
         {
+            IoCManager.Clear ();
             IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
             IoCManager.RegisterInstance (typeof (INavigationService), Substitute.For<INavigationService> ());
         }

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewViewModelTest.cs
@@ -29,6 +29,14 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
     [TestFixture]
     public class RoutesOverviewViewModelTest
     {
+        [TestFixtureSetUp]
+        public void Init ()
+        {
+            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
+            IoCManager.RegisterInstance (typeof (INavigationService), Substitute.For<INavigationService> ());
+            IoCManager.RegisterInstance (typeof (IDbChangedHandler), Substitute.For<IDbChangedHandler> ());
+        }
+
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()
         {

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewViewModelTest.cs
@@ -32,11 +32,11 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         [TestFixtureSetUp]
         public void Init ()
         {
-            IoCManager.Clear ();
-            IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
-            IoCManager.RegisterInstance (typeof (INavigationService), Substitute.For<INavigationService> ());
-            IoCManager.RegisterInstance (typeof (IDbChangedHandler), Substitute.For<IDbChangedHandler> ());
-        }
+            IoCManager.Clear();
+            IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
+            IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
+            IoCManager.RegisterInstance(typeof(IDbChangedHandler), Substitute.For<IDbChangedHandler>());
+            }
 
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewViewModelTest.cs
@@ -30,13 +30,13 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
     public class RoutesOverviewViewModelTest
     {
         [TestFixtureSetUp]
-        public void Init ()
+        public void Init()
         {
             IoCManager.Clear();
             IoCManager.RegisterInstance(typeof(IMediaFileManager), Substitute.For<IMediaFileManager>());
             IoCManager.RegisterInstance(typeof(INavigationService), Substitute.For<INavigationService>());
             IoCManager.RegisterInstance(typeof(IDbChangedHandler), Substitute.For<IDbChangedHandler>());
-            }
+        }
 
         [Test, Category("UnitTest")]
         public void Creation_PropertiesFilled()

--- a/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewViewModelTest.cs
+++ b/Sources/HipMobileUI.Tests/ViewModels/Views/RoutesOverviewViewModelTest.cs
@@ -32,6 +32,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileUITests.ViewModels.Views
         [TestFixtureSetUp]
         public void Init ()
         {
+            IoCManager.Clear ();
             IoCManager.RegisterInstance (typeof (IMediaFileManager), Substitute.For<IMediaFileManager> ());
             IoCManager.RegisterInstance (typeof (INavigationService), Substitute.For<INavigationService> ());
             IoCManager.RegisterInstance (typeof (IDbChangedHandler), Substitute.For<IDbChangedHandler> ());


### PR DESCRIPTION
Cleared IOC Container to remove all instances of registered types
Substituted required interfaces for each test class in order to make them runnable isolatedly


