### PR TITLE
HIPM-861 Wrong authentication token is used

### DIFF
--- a/Sources/HiPMobile/BusinessLayer/Managers/UserRatingManager.cs
+++ b/Sources/HiPMobile/BusinessLayer/Managers/UserRatingManager.cs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.Models;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.Models.ModelClasses;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.Common;
-using PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer;
-using PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.ContentApiAccesses;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.ContentApiAccesses.Contracts;
 using System.Threading.Tasks;
 

--- a/Sources/HiPMobile/ServiceAccessLayer/ContentApiAccesses/UserRatingApiAccess.cs
+++ b/Sources/HiPMobile/ServiceAccessLayer/ContentApiAccesses/UserRatingApiAccess.cs
@@ -16,9 +16,8 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.ContentApiAccesses.Contracts;
 using PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.ContentApiDtos;
-using PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.Models;
-using System;
 using System.Net;
+using PaderbornUniversity.SILab.Hip.Mobile.Shared.Helpers;
 
 namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.ContentApiAccesses
 {
@@ -44,16 +43,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.Content
         public async Task<bool> SendUserRatingAsync(int idForRestApi, int rating)
         {
             var url = RequestPath + idForRestApi + "?Rating=" + rating;
-            var result = await contentApiClient.PostRequestBody(url, String.Empty);
-            if (result.StatusCode == HttpStatusCode.Created)
-            {
-                var jsonPayload = await result.Content.ReadAsStringAsync();
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            var result = await contentApiClient.PostRequestBody(url, string.Empty, Settings.AccessToken);
+            return result.StatusCode == HttpStatusCode.Created;
         }
 
     }

--- a/Sources/HiPMobile/ServiceAccessLayer/ContentApiAccesses/UserRatingApiAccess.cs
+++ b/Sources/HiPMobile/ServiceAccessLayer/ContentApiAccesses/UserRatingApiAccess.cs
@@ -23,7 +23,6 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.Content
 {
     public class UserRatingApiAccess : IUserRatingApiAccess
     {
-
         private readonly IContentApiClient contentApiClient;
 
         private const string RequestPath = "/Exhibits/Rating/";
@@ -35,9 +34,9 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.Content
 
         public async Task<UserRatingDto> GetUserRatingAsync(int idForRestApi)
         {
-                var url = RequestPath + idForRestApi;
-                var json = await contentApiClient.GetResponseFromUrlAsString(url);
-                return JsonConvert.DeserializeObject<UserRatingDto>(json);
+            var url = RequestPath + idForRestApi;
+            var json = await contentApiClient.GetResponseFromUrlAsString(url);
+            return JsonConvert.DeserializeObject<UserRatingDto>(json);
         }
 
         public async Task<bool> SendUserRatingAsync(int idForRestApi, int rating)
@@ -46,6 +45,5 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.Content
             var result = await contentApiClient.PostRequestBody(url, string.Empty, Settings.AccessToken);
             return result.StatusCode == HttpStatusCode.Created;
         }
-
     }
 }

--- a/Sources/HiPMobile/ServiceAccessLayer/ContentApiClient.cs
+++ b/Sources/HiPMobile/ServiceAccessLayer/ContentApiClient.cs
@@ -158,30 +158,22 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
 
         public async Task<HttpResponseMessage> PostRequestFormBased(string url, FormUrlEncodedContent content)
         {
-            try
+            using (HttpClient client = new HttpClient())
             {
-                using (HttpClient client = new HttpClient())
-                {
-                    // Lambda expression executed
-                    // ReSharper disable AccessToDisposedClosure
-                    var result = await TransientRetry.Do(() => client.PostAsync(url, content), new TimeSpan(0, 0, 0, 3));
-                    // ReSharper restore AccessToDisposedClosure
-                    return result;
-                }
-            }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
+                // Lambda expression executed
+                // ReSharper disable AccessToDisposedClosure
+                var result = await TransientRetry.Do(() => client.PostAsync(url, content), new TimeSpan(0, 0, 0, 3));
+                // ReSharper restore AccessToDisposedClosure
+                return result;
             }
         }
 
-        /// <summary>
-        /// Post the specified body to finalUrl := basePath + url.
-        /// </summary>
-        /// <param name="url">URL without basePath</param>
-        /// <param name="body"></param>
-        /// <returns></returns>
         public async Task<HttpResponseMessage> PostRequestBody(string url, string body)
+        {
+            return await PostRequestBody(url, body, token.AccessToken);
+        }
+
+        public async Task<HttpResponseMessage> PostRequestBody(string url, string body, string accessToken)
         {
             using (var client = new HttpClient())
             {
@@ -190,7 +182,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
                 {
                     var content = new StringContent(body, Encoding.UTF8, "application/json");
                     var message = new HttpRequestMessage(HttpMethod.Post, basePath + url) { Content = content };
-                    message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.AccessToken);
+                    message.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                     message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                     return client.SendAsync(message);
                 }, new TimeSpan(0, 0, 0, 3));

--- a/Sources/HiPMobile/ServiceAccessLayer/ContentApiClient.cs
+++ b/Sources/HiPMobile/ServiceAccessLayer/ContentApiClient.cs
@@ -50,9 +50,9 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
         public async Task<string> GetResponseFromUrlAsString(string urlPath)
         {
             var response = await GetHttpWebResponse(urlPath);
-            using (Stream responseStream = response.GetResponseStream())
+            using (var responseStream = response.GetResponseStream())
             {
-                StreamReader reader = new StreamReader(responseStream, Encoding.UTF8);
+                var reader = new StreamReader(responseStream, Encoding.UTF8);
                 return reader.ReadToEnd();
             }
         }
@@ -69,9 +69,9 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
         public async Task<byte[]> GetResponseFromUrlAsBytes(string urlPath)
         {
             var response = await GetHttpWebResponse(urlPath);
-            using (Stream responseStream = response.GetResponseStream())
+            using (var responseStream = response.GetResponseStream())
             {
-                using (MemoryStream ms = new MemoryStream())
+                using (var ms = new MemoryStream())
                 {
                     responseStream.CopyTo(ms);
                     return ms.ToArray();
@@ -86,10 +86,10 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
             {
                 token = await GetTokenForDataStore();
             }
-            string fullUrl = basePath + urlPath;
+            var fullUrl = basePath + urlPath;
             Exception innerException = null;
 
-            for (int i = 0; i < MaxRetryCount; i++)
+            for (var i = 0; i < MaxRetryCount; i++)
             {
                 if (i != 0)
                 {
@@ -119,27 +119,27 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
                 }
             }
 
-            WebException webException = innerException as WebException;
+            var webException = innerException as WebException;
             if (webException != null)
             {
-                WebResponse errorResponse = webException.Response;
+                var errorResponse = webException.Response;
                 var httpResponse = errorResponse as HttpWebResponse;
                 if (httpResponse != null && httpResponse.StatusCode == HttpStatusCode.NotFound)
                 {
                     throw new NotFoundException(fullUrl);
                 }
 
-                using (Stream responseStream = errorResponse.GetResponseStream())
+                using (var responseStream = errorResponse.GetResponseStream())
                 {
-                    StreamReader reader = new StreamReader(responseStream, Encoding.UTF8);
-                    string exceptionMessage = reader.ReadToEnd();
+                    var reader = new StreamReader(responseStream, Encoding.UTF8);
+                    var exceptionMessage = reader.ReadToEnd();
                     throw new NetworkAccessFailedException(exceptionMessage, webException);
                 }
             }
             throw new ArgumentException("Unexpected error during fetching data");
         }
 
-        public async Task<Token> GetTokenForDataStore()
+        private async Task<Token> GetTokenForDataStore()
         {
             var tokenPayload = new TokenPayload
             {
@@ -158,7 +158,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
 
         public async Task<HttpResponseMessage> PostRequestFormBased(string url, FormUrlEncodedContent content)
         {
-            using (HttpClient client = new HttpClient())
+            using (var client = new HttpClient())
             {
                 // Lambda expression executed
                 // ReSharper disable AccessToDisposedClosure
@@ -194,7 +194,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
         {
             try
             {
-                using (HttpClient client = new HttpClient())
+                using (var client = new HttpClient())
                 {
                     var content = new StringContent(jsonContent.ToString(), Encoding.UTF8, "application/json");
                     // Lambda expression executed

--- a/Sources/HiPMobile/ServiceAccessLayer/IContentApiClient.cs
+++ b/Sources/HiPMobile/ServiceAccessLayer/IContentApiClient.cs
@@ -38,6 +38,21 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
 
         Task<HttpResponseMessage> PostRequestFormBased(string url, FormUrlEncodedContent content);
 
+        /// <summary>
+        /// Post the specified body to finalUrl := basePath + url with the standard token from https://hip.eu.auth0.com/oauth/token.
+        /// </summary>
+        /// <param name="url">URL without basePath</param>
+        /// <param name="body"></param>
+        /// <returns></returns>
         Task<HttpResponseMessage> PostRequestBody(string url, string body);
+
+        /// <summary>
+        /// Post the specified body to finalUrl := basePath + url with the given access token as authentication.
+        /// </summary>
+        /// <param name="url">URL without basePath</param>
+        /// <param name="body"></param>
+        /// <param name="accessToken"></param>
+        /// <returns></returns>
+        Task<HttpResponseMessage> PostRequestBody(string url, string body, string accessToken);
     }
 }


### PR DESCRIPTION
In the situation, where the user is logged in and tries to send his rating for an exhibit, the generic access token from this website "https://hip.eu.auth0.com/oauth/token" is used, instead of the token which is associated with the logged-in user. I have implemented a method where the access token is added as parameter, so that the user is now able to send informations (like the user rating) to the server without getting an unauthorized error.