### PR TITLE
HIPM-875 AppetizerPage is missing an appropriate landscape layout

### DIFF
--- a/Sources/HipMobileUI/Pages/AppetizerPage.xaml
+++ b/Sources/HipMobileUI/Pages/AppetizerPage.xaml
@@ -23,53 +23,57 @@
     <ContentPage.Content>
         <views:NotificationExtensionView>
             <views:NotificationExtensionView.ContentTemplate>
-                <AbsoluteLayout>
-                    <Grid AbsoluteLayout.LayoutBounds="1,1,1,1" AbsoluteLayout.LayoutFlags="All" BackgroundColor="White">
+                <AbsoluteLayout x:Name="AbsoluteLayout">
+                    <Grid x:Name="OuterGrid" AbsoluteLayout.LayoutBounds="1,1,1,1" AbsoluteLayout.LayoutFlags="All" BackgroundColor="White">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="0.6*" />
-                            <RowDefinition Height="0.3*" />
-                            <RowDefinition Height="0.1*" />
+                            <RowDefinition Height="0.4*" />
                         </Grid.RowDefinitions>
-                        <Image Source="{Binding Image}" Grid.Row="0" Margin="5" Aspect="AspectFill" />
-                        <ScrollView Grid.Row="1" VerticalOptions="StartAndExpand">
-                            <Grid BackgroundColor="White">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width=".6*" />
-                                    <ColumnDefinition Width=".4*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
-
-                                <ContentView Grid.Column="0" AbsoluteLayout.LayoutBounds="15,15,150,150">
-                                    <controls1:CardView HasShadow="False">
-                                        <Label Text="{Binding Text}"  Margin="10" TextColor="#87000000" FontSize="16"/>
+                        <Image x:Name="Image" Source="{Binding Image}" Grid.Row="0" Aspect="AspectFill" />
+                        <Grid x:Name="InnerGrid" Grid.Row="1" Grid.Column="0" RowSpacing="0" ColumnSpacing="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="0.7*" />
+                                <RowDefinition Height="0.3*" />
+                            </Grid.RowDefinitions>
+                            <ScrollView Grid.Row="0" VerticalOptions="StartAndExpand">
+                                <Grid BackgroundColor="White" Margin="7">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width=".6*" />
+                                        <ColumnDefinition Width=".4*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*" />
+                                    </Grid.RowDefinitions>
+                                    <controls1:CardView Grid.Column="0" HasShadow="False">
+                                        <Label Text="{Binding Text}"  TextColor="#87000000" FontSize="16"/>
                                     </controls1:CardView>
-                                </ContentView>
-                                <StackLayout Grid.Column="1" Spacing="0">
-                                    <StackLayout.GestureRecognizers>
-                                        <TapGestureRecognizer Command="{Binding UserRatingCommand}" NumberOfTapsRequired="1" />
-                                    </StackLayout.GestureRecognizers>
-                                    <Label Text="{Binding RatingAverage}" FontAttributes="Bold" FontSize="24" VerticalOptions="Center" HorizontalOptions="Center" />
-                                    <StackLayout Orientation="Horizontal" HorizontalOptions="Center" VerticalOptions="Center" Spacing="5">
-                                        <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star1}" VerticalOptions="Center"/>
-                                        <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star2}" VerticalOptions="Center"/>
-                                        <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star3}" VerticalOptions="Center"/>
-                                        <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star4}" VerticalOptions="Center"/>
-                                        <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star5}" VerticalOptions="Center"/>
+                                    <StackLayout Grid.Column="1" Spacing="0">
+                                        <StackLayout.GestureRecognizers>
+                                            <TapGestureRecognizer Command="{Binding UserRatingCommand}" NumberOfTapsRequired="1" />
+                                        </StackLayout.GestureRecognizers>
+                                        <Label Text="{Binding RatingAverage}" FontAttributes="Bold" FontSize="24" VerticalOptions="Center" HorizontalOptions="Center" />
+                                        <StackLayout Orientation="Horizontal" HorizontalOptions="Center" VerticalOptions="Center" Spacing="5">
+                                            <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star1}" VerticalOptions="Center"/>
+                                            <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star2}" VerticalOptions="Center"/>
+                                            <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star3}" VerticalOptions="Center"/>
+                                            <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star4}" VerticalOptions="Center"/>
+                                            <Image WidthRequest="16" HeightRequest="16" Source="{Binding Star5}" VerticalOptions="Center"/>
+                                        </StackLayout>
+                                        <Label Text="{Binding RatingCount}" FontSize="12" HorizontalOptions="Center" VerticalOptions="Center" />
                                     </StackLayout>
-                                    <Label Text="{Binding RatingCount}" FontSize="12" HorizontalOptions="Center" VerticalOptions="Center" />
-                                </StackLayout>
-                            </Grid>
-                        </ScrollView>
-
+                                </Grid>
+                            </ScrollView>
+                            <Button Grid.Row="1" Margin="7" BackgroundColor="LightGray"  AbsoluteLayout.LayoutFlags="All"
+                                    Image="ic_file_download.png" IsVisible="{Binding IsDownloadButtonVisible}" Command="{Binding DownloadCommand}" />
+                        </Grid>
                     </Grid>
-                    <Button AbsoluteLayout.LayoutBounds=".5,1,1,.13" Margin="7" BackgroundColor="LightGray"  AbsoluteLayout.LayoutFlags="All"
-                    Image="ic_file_download.png" IsVisible="{Binding IsDownloadButtonVisible}" Command="{Binding DownloadCommand}" />
-                    <Button AbsoluteLayout.LayoutBounds="1,.5,.2,.1" AbsoluteLayout.LayoutFlags="All"
+                    <Button x:Name="NextSideButton" AbsoluteLayout.LayoutBounds="1,0.5,0.2,0.1" AbsoluteLayout.LayoutFlags="All"
                     Image="ic_chevron_right" IsVisible="{Binding NextVisible}" Command="{Binding NextViewCommand}" BackgroundColor="#80D3D3D3" AutomationId="NextButton"/>
                 </AbsoluteLayout>
             </views:NotificationExtensionView.ContentTemplate>

--- a/Sources/HipMobileUI/Pages/AppetizerPage.xaml.cs
+++ b/Sources/HipMobileUI/Pages/AppetizerPage.xaml.cs
@@ -11,17 +11,69 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+using PaderbornUniversity.SILab.Hip.Mobile.UI.Helpers;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.Navigation;
 using PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages;
-
+using Xamarin.Forms;
 
 namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Pages
 {
     public partial class AppetizerPage : IViewFor<AppetizerPageViewModel>
     {
+        private DeviceOrientation orientation;
+
         public AppetizerPage()
         {
             InitializeComponent();
+            orientation = DeviceOrientation.Undefined;
+        }
+
+        /// <summary>
+        /// Size changed, determine if we need to update the layout.
+        /// </summary>
+        /// <param name="width">The new width.</param>
+        /// <param name="height">The new height.</param>
+        protected override void OnSizeAllocated(double width, double height)
+        {
+            base.OnSizeAllocated(width, height);
+            if (width > height && orientation != DeviceOrientation.Landscape)
+            {
+                orientation = DeviceOrientation.Landscape;
+                OuterGrid.RowDefinitions.Clear();
+                OuterGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+                OuterGrid.ColumnDefinitions.Clear();
+                OuterGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(0.5, GridUnitType.Star) });
+                OuterGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(0.5, GridUnitType.Star) });
+                OuterGrid.Children.Remove(Image);
+                OuterGrid.Children.Add(Image, 0, 0);
+                OuterGrid.Children.Remove(InnerGrid);
+                OuterGrid.Children.Add(InnerGrid, 1, 0);
+                InnerGrid.RowDefinitions.Clear();
+                InnerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.8, GridUnitType.Star) });
+                InnerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.2, GridUnitType.Star) });
+                Image.Margin = new Thickness(5, 5, 0, 5);
+                AbsoluteLayout.Children.Remove(NextSideButton);
+                AbsoluteLayout.Children.Add(NextSideButton, new Rectangle(1, 0.5, 0.15, 0.25), AbsoluteLayoutFlags.All);
+            }
+            else if (width < height && orientation != DeviceOrientation.Portrait)
+            {
+                orientation = DeviceOrientation.Portrait;
+                OuterGrid.ColumnDefinitions.Clear();
+                OuterGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+                OuterGrid.RowDefinitions.Clear();
+                OuterGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.6, GridUnitType.Star) });
+                OuterGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.4, GridUnitType.Star) });
+                OuterGrid.Children.Remove(Image);
+                OuterGrid.Children.Add(Image, 0, 0);
+                OuterGrid.Children.Remove(InnerGrid);
+                OuterGrid.Children.Add(InnerGrid, 0, 1);
+                InnerGrid.RowDefinitions.Clear();
+                InnerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.7, GridUnitType.Star) });
+                InnerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.3, GridUnitType.Star) });
+                Image.Margin = new Thickness(5, 5, 5, 0);
+                AbsoluteLayout.Children.Remove(NextSideButton);
+                AbsoluteLayout.Children.Add(NextSideButton, new Rectangle(1, 0.5, 0.2, 0.1), AbsoluteLayoutFlags.All);
+            }
         }
     }
 }

--- a/Sources/HipMobileUI/Pages/UserRatingPage.xaml.cs
+++ b/Sources/HipMobileUI/Pages/UserRatingPage.xaml.cs
@@ -51,6 +51,9 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Pages
                 OuterGrid.Children.Add(InnerGrid1, 0, 0);
                 OuterGrid.Children.Remove(InnerGrid2);
                 OuterGrid.Children.Add(InnerGrid2, 1, 0);
+                InnerGrid2.RowDefinitions.Clear();
+                InnerGrid2.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.8, GridUnitType.Star) });
+                InnerGrid2.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.2, GridUnitType.Star) });
             }
             else if (width < height && orientation != DeviceOrientation.Portrait)
             {
@@ -66,6 +69,9 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Pages
                 OuterGrid.Children.Add(InnerGrid1, 0, 0);
                 OuterGrid.Children.Remove(InnerGrid2);
                 OuterGrid.Children.Add(InnerGrid2, 0, 1);
+                InnerGrid2.RowDefinitions.Clear();
+                InnerGrid2.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.7, GridUnitType.Star) });
+                InnerGrid2.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.3, GridUnitType.Star) });
             }
         }
     }


### PR DESCRIPTION
I have modified the AppetizerPage.xaml.cs so that the row and column definitions of the outer grid will be changed on screen rotation. The image position will be adjusted too.
This can be tested by going to the AppetizerPage and change the screen orientation.