### PR TITLE
hotfix-hipm-917 - Fix of download functionality

### DIFF
--- a/Sources/HipMobileUI/Pages/ExhibitRouteDownloadPage.xaml
+++ b/Sources/HipMobileUI/Pages/ExhibitRouteDownloadPage.xaml
@@ -27,9 +27,17 @@
         <views:NotificationExtensionView>
             <views:NotificationExtensionView.ContentTemplate>
                 <Grid x:Name="OuterGrid" AbsoluteLayout.LayoutBounds="1,1,1,1" AbsoluteLayout.LayoutFlags="All" BackgroundColor="White">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="0.6*" />
+                        <RowDefinition Height="0.4*" />
+                    </Grid.RowDefinitions>
                     <!--The row and column definition is made in code to adjust them to the device orientation-->
                     <Image x:Name="Image" Source="{Binding Image}" Grid.Row="0" Aspect="AspectFill" />
                     <Grid x:Name="InnerGrid" Grid.Row="1" Grid.Column="0" RowSpacing="0" ColumnSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="0.7*" />
+                            <RowDefinition Height="0.3*" />
+                        </Grid.RowDefinitions>
                         <!--The row and column definition is made in code to adjust them to the device orientation-->
                         <StackLayout Grid.Row="0" VerticalOptions="CenterAndExpand" Margin="20,20,20,20" >
                             <Label IsVisible="{Binding DescriptionExists}" Text="{Binding DownloadableDescription}" FontSize="Medium" TextColor="{StaticResource AccentDarkColor}"

--- a/Sources/HipMobileUI/Pages/ExhibitRouteDownloadPage.xaml.cs
+++ b/Sources/HipMobileUI/Pages/ExhibitRouteDownloadPage.xaml.cs
@@ -22,7 +22,6 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Pages
             base.OnSizeAllocated(width, height);
             if (width > height && orientation != DeviceOrientation.Landscape)
             {
-                orientation = DeviceOrientation.Landscape;
                 OuterGrid.RowDefinitions.Clear();
                 OuterGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
                 OuterGrid.ColumnDefinitions.Clear();
@@ -36,10 +35,10 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Pages
                 InnerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.8, GridUnitType.Star) });
                 InnerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.2, GridUnitType.Star) });
                 Image.Margin = new Thickness(5, 5, 0, 5);
+                orientation = DeviceOrientation.Landscape;
             }
             else if (width < height && orientation != DeviceOrientation.Portrait)
             {
-                orientation = DeviceOrientation.Portrait;
                 OuterGrid.ColumnDefinitions.Clear();
                 OuterGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
                 OuterGrid.RowDefinitions.Clear();
@@ -53,6 +52,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Pages
                 InnerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.7, GridUnitType.Star) });
                 InnerGrid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(0.3, GridUnitType.Star) });
                 Image.Margin = new Thickness(5, 5, 5, 0);
+                orientation = DeviceOrientation.Portrait;
             }
         }
     }

--- a/Sources/HipMobileUI/ViewModels/Pages/ExhibitRouteDownloadPageViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Pages/ExhibitRouteDownloadPageViewModel.cs
@@ -32,15 +32,9 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
 {
     public class ExhibitRouteDownloadPageViewModel : NavigationViewModel, IProgressListener
     {
-        private readonly IDownloadable downloadable;
-
         public ExhibitRouteDownloadPageViewModel(IDownloadable downloadable, IDownloadableListItemViewModel downloadableListItemViewModel)
         {
-            this.downloadable = downloadable;
-            DownloadableId = downloadable.Id;
-            DownloadableIdForRestApi = downloadable.IdForRestApi;
-            DownloadableName = downloadable.Name;
-            DownloadableDescription = downloadable.Description;
+            Downloadable = downloadable;
             //Remove the description label if no description exists to center the other labels precisely
             DescriptionExists = !(DownloadableDescription == null || DownloadableDescription.Equals(""));
 
@@ -63,74 +57,60 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
 
         private IDownloadableListItemViewModel DownloadableListItemViewModel { get; set; }
 
-        private string downloadableName;
 
-        public string DownloadableName
+        private IDownloadable downloadable;
+        public IDownloadable Downloadable
         {
-            get { return downloadableName; }
-            set { SetProperty(ref downloadableName, value); }
+            get => downloadable;
+            set => SetProperty(ref downloadable, value);
         }
 
-        private string downloadableId;
+        public string DownloadableName => Downloadable.Name;
 
-        public string DownloadableId
-        {
-            get { return downloadableId; }
-            set { SetProperty(ref downloadableId, value); }
-        }
+        public string DownloadableDescription => Downloadable.Description;
 
-        private int downloadableIdForRestApi;
+        public string DownloadableId => Downloadable.Id;
 
-        public int DownloadableIdForRestApi
-        {
-            get { return downloadableIdForRestApi; }
-            set { SetProperty(ref downloadableIdForRestApi, value); }
-        }
+        public int DownloadableIdForRestApi => Downloadable.IdForRestApi;
 
         private ImageSource image;
-
         public ImageSource Image
         {
-            get { return image; }
-            set { SetProperty(ref image, value); }
+            get => image;
+            set => SetProperty(ref image, value);
         }
 
         private double loadingProgress;
-
         public double LoadingProgress
         {
-            get { return loadingProgress; }
-            set { SetProperty(ref loadingProgress, value); }
+            get => loadingProgress;
+            set => SetProperty(ref loadingProgress, value);
         }
 
         private bool descriptionExists;
         public bool DescriptionExists
         {
-            get { return descriptionExists; }
-            set { SetProperty(ref descriptionExists, value); }
-        }
-
-        private string downloadableDescription;
-        public string DownloadableDescription
-        {
-            get { return downloadableDescription; }
-            set { SetProperty(ref downloadableDescription, value); }
+            get => descriptionExists;
+            set => SetProperty(ref descriptionExists, value);
         }
 
         private ICommand startDownload;
-
         public ICommand StartDownload
         {
-            get { return startDownload; }
-            set { SetProperty(ref startDownload, value); }
+            get => startDownload;
+            set => SetProperty(ref startDownload, value);
         }
 
         public ICommand CancelCommand { get; }
-
         private void CancelDownload()
         {
             cancellationTokenSource?.Cancel();
             CloseDownloadPage();
+        }
+
+        private void OpenDetailsView()
+        {
+            DownloadableListItemViewModel.OpenDetailsView(DownloadableId);
         }
 
         private void CloseDownloadPage()
@@ -168,7 +148,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
                 {
                     try
                     {
-                        //await fullDownloadableDataFetcher.FetchFullDownloadableDataIntoDatabase(DownloadableId, DownloadableIdForRestApi, cancellationTokenSource.Token, this);
+                        await fullDownloadableDataFetcher.FetchFullDownloadableDataIntoDatabase(DownloadableId, DownloadableIdForRestApi, cancellationTokenSource.Token, this);
                     }
                     catch (Exception e)
                     {
@@ -205,8 +185,12 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
 
             if (!cancellationTokenSource.IsCancellationRequested && isDownloadAllowed)
             {
-                //DownloadableListItemViewModel.SetDetailsAvailable(true);
-                //CloseDownloadPage();
+                DownloadableListItemViewModel.SetDetailsAvailable(true);
+
+                if (DownloadableListItemViewModel.GetType() != typeof(AppetizerPageViewModel))
+                    OpenDetailsView();
+                else
+                    CloseDownloadPage();
             }
             IoCManager.Resolve<IDbChangedHandler>().NotifyAll();
         }


### PR DESCRIPTION
[HIPM-917](https://atlassian-hip.cs.uni-paderborn.de/jira/browse/HIPM-917)

The download functionality on the master is broken which this hotfix is supposed to fix.

**Testing:**
Download details data for exhibits and routes.
After the download of an exhibit its AppetizerPage should be displayed (from OverviewPage and AppetizerPage).
After the download of a route its DetailsPage is shown.