### PR TITLE
Small changes for a more consistent UI experience

### DIFF
--- a/Sources/HipMobileUI/App.xaml
+++ b/Sources/HipMobileUI/App.xaml
@@ -40,10 +40,7 @@
             <Color x:Key="OrangeBarColor">#FEB533</Color>
             <Color x:Key="RedBarColor">#FF8E59</Color>
 
-
-            
-
-            
+            <!--Fonts used in the app -->
             <Style x:Key="Ssp-ExtraLight" TargetType="Label">
                 <Setter Property="FontFamily">
                     <Setter.Value>
@@ -193,6 +190,9 @@
             <Style TargetType="Label">
                 <Setter Property="FontSize" Value="12" />
                 <Setter Property="TextColor" Value="Black" />
+            </Style>
+            <Style TargetType="Button">
+                <Setter Property="BackgroundColor" Value="{StaticResource MediumGrayColor}" />
             </Style>
             <!--#endregion-->
 

--- a/Sources/HipMobileUI/Pages/AppetizerPage.xaml
+++ b/Sources/HipMobileUI/Pages/AppetizerPage.xaml
@@ -57,7 +57,7 @@
                                     </StackLayout>
                                 </Grid>
                             </ScrollView>
-                            <Button Grid.Row="1" Margin="7" BackgroundColor="{StaticResource MediumGrayColor}"  AbsoluteLayout.LayoutFlags="All"
+                            <Button Grid.Row="1" Margin="7" AbsoluteLayout.LayoutFlags="All"
                                     Image="ic_file_download.png" IsVisible="{Binding IsDownloadButtonVisible}" Command="{Binding DownloadCommand}" />
                         </Grid>
                     </Grid>

--- a/Sources/HipMobileUI/Pages/ExhibitRouteDownloadPage.xaml
+++ b/Sources/HipMobileUI/Pages/ExhibitRouteDownloadPage.xaml
@@ -52,7 +52,7 @@
                             <Label Text="{Binding LoadingProgress, StringFormat='{0:p0}'}"
                                    HorizontalTextAlignment="Center" FontSize="16" />
                         </StackLayout>
-                        <Button Grid.Row="1" Margin="7" BackgroundColor="LightGray" Text="{helpers:Translate Cancel}" 
+                        <Button Grid.Row="1" Margin="7" Text="{helpers:Translate Cancel}" 
                                 FontSize="13" Command="{Binding CancelCommand}" />
                     </Grid>
                 </Grid>

--- a/Sources/HipMobileUI/Pages/UserRatingPage.xaml
+++ b/Sources/HipMobileUI/Pages/UserRatingPage.xaml
@@ -170,7 +170,7 @@
                             </Image>
                         </StackLayout>
                     </StackLayout>
-                    <Button  Grid.Row="1"  Margin="7" BackgroundColor="LightGray" 
+                    <Button  Grid.Row="1"  Margin="7" 
                          Text="{helpers:Translate UserRating_Rate}" FontSize="13"  Command="{Binding SendRatingCommand}" />
                 </Grid>
             </Grid>

--- a/Sources/HipMobileUI/Views/LicenseScreenView.xaml
+++ b/Sources/HipMobileUI/Views/LicenseScreenView.xaml
@@ -64,7 +64,7 @@
 
                         <!-- Labels for contribution -->
                         <Label Style="{DynamicResource Heading1Style}"
-                               Text="{helpers:Translate LicenseScreenView_Contribution_Title}" />
+                               Text="{helpers:Translate LicenseScreenView_Contribution_Title}" Margin="0,20,0,0" />
                         <BoxView Style="{StaticResource LicenseBoxViewStyle}"/>
                         <Label Style="{StaticResource Heading2Style}"
                                Text="{helpers:Translate LicenseScreenView_CreditsImagesAutocarousel_Title}" />
@@ -75,7 +75,8 @@
                         <views1:HtmlLink Text="{helpers:Translate LicenseScreenView_CreditsImagesCharacterSelection_Text}" />
 
                         <!-- Labels for Terms of Use -->
-                        <Label Style="{DynamicResource Heading1Style}" Text="{helpers:Translate LicenseScreenView_ToU_Title}" />
+                        <Label Style="{DynamicResource Heading1Style}"
+                               Text="{helpers:Translate LicenseScreenView_ToU_Title}" Margin="0,20,0,0" />
                         <BoxView Style="{StaticResource LicenseBoxViewStyle}"/>
                         <Label Style="{StaticResource BasicTextStyle}"
                                Text="{helpers:Translate LicenseScreenView_ToU_Text}" />
@@ -90,7 +91,7 @@
 
                         <!-- Labels for Privacy Policy -->
                         <Label Style="{DynamicResource Heading1Style}"
-                               Text="{helpers:Translate LicenseScreenView_PrivacyPolicy_Title}" />
+                               Text="{helpers:Translate LicenseScreenView_PrivacyPolicy_Title}" Margin="0,20,0,0" />
                         <BoxView Style="{StaticResource LicenseBoxViewStyle}"/>
                         <Label Style="{StaticResource BasicTextStyle}"
                                Text="{helpers:Translate LicenseScreenView_PrivacyPolicy_Text}" />
@@ -124,7 +125,8 @@
                                Text="{helpers:Translate LicenseScreenView_FurtherInfo_Text}" />
 
                         <!-- Labels for Impressum -->
-                        <Label Style="{DynamicResource Heading1Style}" Text="{helpers:Translate LicenseScreenView_Impressum_Title}">
+                        <Label Style="{DynamicResource Heading1Style}"
+                               Text="{helpers:Translate LicenseScreenView_Impressum_Title}" Margin="0,20,0,0">
                             <Label.GestureRecognizers>
                                 <TapGestureRecognizer Command="{Binding UnlockExhibits}" />
                             </Label.GestureRecognizers>

--- a/Sources/HipMobileUI/Views/ProfileScreenView.xaml
+++ b/Sources/HipMobileUI/Views/ProfileScreenView.xaml
@@ -78,12 +78,10 @@
                                 <Button WidthRequest="200" HeightRequest="40"
                                         Command="{Binding ChangeAppModeCommand}"
                                         Text="{helpers:Translate ProfileView_Button_Change_App_Mode}"
-                                        TextColor="Black"
-                                        BackgroundColor="{StaticResource MediumGrayColor}" />
+                                        TextColor="Black" />
                                 <Button WidthRequest="200" HeightRequest="40"
                                         Command="{Binding Logout}" Text="{helpers:Translate Logout}"
-                                        TextColor="Black"
-                                        BackgroundColor="{StaticResource MediumGrayColor}" />
+                                        TextColor="Black" />
                             </StackLayout>
                         </Grid>
 

--- a/Sources/HipMobileUI/Views/RoutesOverviewView.xaml
+++ b/Sources/HipMobileUI/Views/RoutesOverviewView.xaml
@@ -72,8 +72,7 @@
                                                 </StackLayout>
                                             </StackLayout>
                                         </StackLayout>
-                                        <Button BorderRadius="2" BackgroundColor="{StaticResource MediumGrayColor}"
-                                                WidthRequest="40" Image="ic_file_download.png"
+                                        <Button WidthRequest="40" Image="ic_file_download.png"
                                                 IsVisible="{Binding IsDownloadPanelVisible}"
                                                 Command="{Binding DownloadCommand}" />
                                     </StackLayout>


### PR DESCRIPTION
_This can be seen as a follow-up PR for the recent inclusion of the design guidelines._

License and settings page are more in sync with each other and all buttons share the same standard background color.