### PR TITLE
Fix NullReferenceExceptions due to achievements having no nextId

### DIFF
--- a/Sources/HiPMobile/BusinessLayer/DtoToModelConverters/ExhibitsVisitedAchievementConverter.cs
+++ b/Sources/HiPMobile/BusinessLayer/DtoToModelConverters/ExhibitsVisitedAchievementConverter.cs
@@ -24,7 +24,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.DtoToModelCo
             existingModelObject.Description = dto.Description;
             existingModelObject.Id = dto.Id.ToString();
             existingModelObject.ThumbnailUrl = dto.ThumbnailUrl;
-            existingModelObject.NextId = dto.NextId.ToString();
+            existingModelObject.NextId = dto.NextId?.ToString();
             existingModelObject.Title = dto.Title;
             existingModelObject.Count = dto.Count;
             existingModelObject.Points = dto.Points;

--- a/Sources/HiPMobile/BusinessLayer/DtoToModelConverters/RouteFinishedAchievementConverter.cs
+++ b/Sources/HiPMobile/BusinessLayer/DtoToModelConverters/RouteFinishedAchievementConverter.cs
@@ -10,7 +10,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.DtoToModelCo
             existingModelObject.Description = dto.Description;
             existingModelObject.Id = dto.Id.ToString();
             existingModelObject.ThumbnailUrl = dto.ThumbnailUrl;
-            existingModelObject.NextId = dto.NextId.ToString();
+            existingModelObject.NextId = dto.NextId?.ToString();
             existingModelObject.Title = dto.Title;
             existingModelObject.Points = dto.Points;
             existingModelObject.RouteId = dto.RouteId;

--- a/Sources/HiPMobile/BusinessLayer/Models/ModelClasses/AchievementBase.cs
+++ b/Sources/HiPMobile/BusinessLayer/Models/ModelClasses/AchievementBase.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using JetBrains.Annotations;
+
 namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.Models
 {
     /// <remarks>
@@ -28,7 +30,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.BusinessLayer.Models
 
         public string ThumbnailUrl { get; set; }
 
-        public string NextId { get; set; }
+        [CanBeNull] public string NextId { get; set; }
 
         public bool IsUnlocked { get; set; }
 

--- a/Sources/HiPMobile/ServiceAccessLayer/ContentApiDtos/AchievementDto.cs
+++ b/Sources/HiPMobile/ServiceAccessLayer/ContentApiDtos/AchievementDto.cs
@@ -31,7 +31,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.Content
         public string ThumbnailUrl { get; private set; }
 
         [JsonProperty("nextId")]
-        public int NextId { get; private set; }
+        public int? NextId { get; private set; }
 
         [JsonProperty("points")]
         public int Points { get; private set; }
@@ -40,7 +40,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.Content
         {
         }
 
-        public AchievementDto(int id, string title, string description, string thumbnailUrl, int nextId, int points)
+        public AchievementDto(int id, string title, string description, string thumbnailUrl, int? nextId, int points)
         {
             Id = id;
             Title = title;
@@ -61,7 +61,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.Content
         {
         }
 
-        public RouteFinishedAchievementDto(int id, string title, string description, string thumbnailUrl, int nextId, int points, int routeId) :
+        public RouteFinishedAchievementDto(int id, string title, string description, string thumbnailUrl, int? nextId, int points, int routeId) :
             base(id, title, description, thumbnailUrl, nextId, points)
         {
             RouteId = routeId;
@@ -77,7 +77,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.Content
         {
         }
 
-        public ExhibitsVisitedAchievementDto(int id, string title, string description, string thumbnailUrl, int nextId, int count, int points) :
+        public ExhibitsVisitedAchievementDto(int id, string title, string description, string thumbnailUrl, int? nextId, int count, int points) :
             base(id, title, description, thumbnailUrl, nextId, points)
         {
             Count = count;

--- a/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/AchievementConverterTest.cs
+++ b/Sources/HipMobile.Tests/BusinessLayer/DtoToModelConverters/AchievementConverterTest.cs
@@ -51,7 +51,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileTests.BusinessLayer.DtoT
                 Assert.AreEqual(routeFinishedAchievementDto.Description, routeFinishedAchievement.Description);
                 Assert.AreEqual(routeFinishedAchievementDto.ThumbnailUrl, routeFinishedAchievement.ThumbnailUrl);
                 Assert.AreEqual(routeFinishedAchievementDto.Title, routeFinishedAchievement.Title);
-                Assert.AreEqual(routeFinishedAchievementDto.NextId.ToString(), routeFinishedAchievement.NextId);
+                Assert.AreEqual(routeFinishedAchievementDto.NextId?.ToString(), routeFinishedAchievement.NextId);
                 Assert.AreEqual(routeFinishedAchievementDto.Points, routeFinishedAchievement.Points);
                 Assert.AreEqual(routeFinishedAchievementDto.RouteId, routeFinishedAchievement.RouteId);
 
@@ -78,7 +78,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.HipMobileTests.BusinessLayer.DtoT
                 Assert.AreEqual(exhibitsVisitedAchievementDto.ThumbnailUrl, exhibitsVisitedAchievement.ThumbnailUrl);
                 Assert.AreEqual(exhibitsVisitedAchievementDto.Title, exhibitsVisitedAchievement.Title);
                 Assert.AreEqual(exhibitsVisitedAchievementDto.Count, exhibitsVisitedAchievement.Count);
-                Assert.AreEqual(exhibitsVisitedAchievementDto.NextId.ToString(), exhibitsVisitedAchievement.NextId);
+                Assert.AreEqual(exhibitsVisitedAchievementDto.NextId?.ToString(), exhibitsVisitedAchievement.NextId);
                 Assert.AreEqual(exhibitsVisitedAchievementDto.Points, exhibitsVisitedAchievement.Points);
 
                 return null;


### PR DESCRIPTION
Not every achievement needs to have a pointer to another achievement and this PR fixes errors occurring when this is not the case.

This should be merged soon as the app is currently showing many errors.