### PR TITLE
fixing HIPM-976: Color variation between exhibit page and menu

### DIFF
--- a/Sources/HipMobileUI/Appearance/ThemeManager.cs
+++ b/Sources/HipMobileUI/Appearance/ThemeManager.cs
@@ -65,12 +65,12 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.Appearance
 
         private void ChangeToAdventurerTheme()
         {
-            barsColorsChanger.ChangeToolbarColor(GetResourceColor("SecondaryDarkColor"), GetResourceColor("SecondaryColor"));
+            barsColorsChanger.ChangeToolbarColor(GetResourceColor("SecondaryDarkColor"), GetResourceColor("SecondaryDarkColor"));
         }
 
         private void ChangeToProfessorTheme()
         {
-            barsColorsChanger.ChangeToolbarColor(GetResourceColor("PrimaryDarkColor"), GetResourceColor("PrimaryColor"));
+            barsColorsChanger.ChangeToolbarColor(GetResourceColor("PrimaryDarkColor"), GetResourceColor("PrimaryDarkColor"));
         }
 
         private Color GetResourceColor(string color)


### PR DESCRIPTION
fixing HIPM-976: ExhibitsOverview as well as exhibits and Menu in AdventurerMode now use more consistent coloring through the ThemeManager