### PR TITLE
Iss hipm 978 - Disable Adventurer Mode

### DIFF
--- a/Sources/HiPMobile/Helpers/Settings.cs
+++ b/Sources/HiPMobile/Helpers/Settings.cs
@@ -26,7 +26,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.Helpers
 
             public event PropertyChangedEventHandler PropertyChanged;
         }
-        
+
         /// <summary>
         /// Some properties in this class notify this instance
         /// about changes to them.
@@ -307,14 +307,19 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.Helpers
 
         private const string ShouldDeleteDbOnLaunchKey = "should_delete_db_on_launch_key";
         private static readonly string ShouldDeleteDbOnLaunchDefault = false.ToString();
-         
+
         /// <summary>
-        /// Iff set to true, the IDataAccess database is deleted on next app launch.
+        /// If set to true, the IDataAccess database is deleted on next app launch.
         /// </summary>
         public static bool ShouldDeleteDbOnLaunch
         {
             get => bool.Parse(AppSettings.GetValueOrDefault(ShouldDeleteDbOnLaunchKey, ShouldDeleteDbOnLaunchDefault));
             set => AppSettings.AddOrUpdateValue(ShouldDeleteDbOnLaunchKey, value.ToString());
         }
+
+        /// <summary>
+        /// If set to true, the user cannot chose between the two modes.
+        /// </summary>
+        public static bool DisableAdventurerMode = true;
     }
 }

--- a/Sources/HiPMobile/Helpers/Settings.cs
+++ b/Sources/HiPMobile/Helpers/Settings.cs
@@ -318,7 +318,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.Helpers
         }
 
         /// <summary>
-        /// If set to true, the user cannot chose between the two modes.
+        /// If set to true, the user cannot choose between the two modes.
         /// </summary>
         public static bool DisableAdventurerMode = true;
     }

--- a/Sources/HipMobileUI/App.xaml.cs
+++ b/Sources/HipMobileUI/App.xaml.cs
@@ -35,6 +35,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI
                 return;
 
             // Handle when your app starts
+            Settings.AdventurerMode = Settings.AdventurerMode && !Settings.DisableAdventurerMode;
 
             // set the first page that is shown
             var navigationService = IoCManager.Resolve<INavigationService>();

--- a/Sources/HipMobileUI/ViewModels/Pages/UserOnboardingPageViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Pages/UserOnboardingPageViewModel.cs
@@ -59,8 +59,15 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Pages
             // update the settings to not show this page next time
             Settings.RepeatIntro = false;
 
-            // open the character selection page
-            Navigation.StartNewLocalNavigationStack(new CharacterSelectionPageViewModel(this));
+            if (Settings.DisableAdventurerMode)
+            {
+                Navigation.StartNewNavigationStack(new LoadingPageViewModel());
+            }
+            else
+            {
+                // open the character selection page
+                Navigation.StartNewLocalNavigationStack(new CharacterSelectionPageViewModel(this));
+            }
         }
 
         /// <summary>

--- a/Sources/HipMobileUI/ViewModels/Views/ProfileScreenViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Views/ProfileScreenViewModel.cs
@@ -31,6 +31,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
 
             Tabs = new ObservableCollection<string> { Strings.MainPageViewModel_OverviewPage, Strings.ProfileView_Statistic };
 
+            AppModeVisible = !Settings.DisableAdventurerMode;
             ChangeAppModeCommand = new Command(OnChangeAppModeTapped);
             Logout = new Command(LogoutDummy);
         }
@@ -46,6 +47,19 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
         public int Score => Settings.Score;
         public string AchievementCount => Settings.Achievements + " / 30";
         public string Completeness => Settings.Completeness + "%";
+
+        /// <summary>
+        /// If the adventurer mode is disabled, hide the options for mode switching
+        /// </summary>
+        private bool appModeVisible;
+        public bool AppModeVisible
+        {
+            get { return appModeVisible; }
+            set
+            {
+                SetProperty(ref appModeVisible, value);
+            }
+        }
 
         private void OnChangeAppModeTapped()
         {

--- a/Sources/HipMobileUI/ViewModels/Views/SettingsScreenViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Views/SettingsScreenViewModel.cs
@@ -36,6 +36,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
             RemoveAllDownloads = new Command(RemoveAllDownloadsClicked);
             SelectCharacterCommand = new Command(OnSelectCharacterTapped);
             Size = BuildSizeDescription();
+            AppModeVisible = !Settings.DisableAdventurerMode;
         }
 
         public ICommand RemoveAllDownloads { get; }
@@ -65,6 +66,19 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
             var dbSizeMb = IoCManager.Resolve<IStorageSizeProvider>().GetDatabaseSizeMb();
             var mediaSizeMb = IoCManager.Resolve<IMediaFileManager>().TotalSizeBytes / (1024 * 1024);
             return $"{dbSizeMb + mediaSizeMb} MB";
+        }
+
+        /// <summary>
+        /// If the adventurer mode is disabled, hide the options for mode switching
+        /// </summary>
+        private bool appModeVisible;
+        public bool AppModeVisible
+        {
+            get { return appModeVisible; }
+            set
+            {
+                SetProperty(ref appModeVisible, value);
+            }
         }
 
         /// <summary>

--- a/Sources/HipMobileUI/Views/ProfileScreenView.xaml
+++ b/Sources/HipMobileUI/Views/ProfileScreenView.xaml
@@ -43,7 +43,7 @@
                                 <Image WidthRequest="200" HeightRequest="50" Aspect="AspectFit" Source="{Binding Avatar}" />
                                 <Label Text="{Binding Username}" FontAttributes="Bold" FontSize="20"
                                        HorizontalTextAlignment="Center" TextColor="{StaticResource DarkGrayColor}" Style="{DynamicResource Ssp-Regular}"/>
-                                <Label Text="{Binding Character}" FontSize="15" HorizontalTextAlignment="Center"
+                                <Label Text="{Binding Character}" FontSize="15" HorizontalTextAlignment="Center" IsVisible="{Binding AppModeVisible}"
                                        TextColor="{StaticResource PrimaryDarkColor}" Style="{DynamicResource Ssp-SemiBold}"/>
                                 <Label Text="{Binding EMail}" FontSize="10" HorizontalTextAlignment="Center" Margin="0" Style="{DynamicResource Ssp-Regular}"/>
                             </StackLayout>
@@ -76,7 +76,7 @@
                             <StackLayout x:Name="Logout" Grid.Row="2" HorizontalOptions="Center" VerticalOptions="End"
                                          Padding="3">
                                 <Button WidthRequest="200" HeightRequest="40"
-                                        Command="{Binding ChangeAppModeCommand}"
+                                        Command="{Binding ChangeAppModeCommand}" IsVisible="{Binding AppModeVisible}"
                                         Text="{helpers:Translate ProfileView_Button_Change_App_Mode}"
                                         TextColor="Black" />
                                 <Button WidthRequest="200" HeightRequest="40"

--- a/Sources/HipMobileUI/Views/SettingsScreenView.xaml
+++ b/Sources/HipMobileUI/Views/SettingsScreenView.xaml
@@ -142,13 +142,14 @@
                         <Label Style="{DynamicResource Heading1Style}"
                                Text="{helpers:Translate SettingsScreenView_FurtherSettings_Title}" Grid.Row="16"
                                Grid.Column="0" Grid.ColumnSpan="2" Margin="0,20,0,10" />
-                        <Label Style="{StaticResource BasicTextStyle}"
+                        <Label Style="{StaticResource BasicTextStyle}" IsVisible="{Binding AppModeVisible}"
                                Grid.Row="17" Grid.Column="0" Text="{Binding AppModeText}" />
-                        <Button Style="{DynamicResource Button}"
+                        <Button Style="{DynamicResource Button}" IsVisible="{Binding AppModeVisible}"
                                 Grid.Row="17" Grid.Column="1" Command="{Binding SelectCharacterCommand}"
                                 Text="{helpers:Translate SettingsScreenView_CharacterSelection_Button_Text}"
                                 TextColor="White" />
-                        <BoxView Grid.Row="18" Grid.Column="0" Style="{StaticResource SettingsBoxViewStyle}" />
+                        <BoxView Grid.Row="18" Grid.Column="0" IsVisible="{Binding AppModeVisible}"
+                                 Style="{StaticResource SettingsBoxViewStyle}" />
                         <Label Style="{StaticResource BasicTextStyle}"
                                Text="{helpers:Translate StorageTitle}" Grid.Row="19" Grid.Column="0" />
                         <Label Style="{StaticResource BasicTextStyle}"


### PR DESCRIPTION
I have added a setting "DisableAdventurerMode" in the Settings.cs classs. If this variable is set to true,  the user can no longer choose between two modes after the intro page. Furthermore, the option to switch the mode in the settings and in the profile page is disappeared.