### PR TITLE
iss-hipm-979 - App now recognizes the successful creation of an account

### DIFF
--- a/Sources/HiPMobile/ServiceAccessLayer/AuthenticationApiAccess/AuthApiAccess.cs
+++ b/Sources/HiPMobile/ServiceAccessLayer/AuthenticationApiAccess/AuthApiAccess.cs
@@ -61,7 +61,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer.Authent
 
             var result = await clientApiClient.PostRequestBody(ServerEndpoints.RegisterUrl, content, false);
 
-            if (result.StatusCode == HttpStatusCode.OK)
+            if (result.StatusCode == HttpStatusCode.Created)
             {
                 return true;
             }


### PR DESCRIPTION
The "registration failed" message now only appears, if the registration actually failed. If it succeeds, the app opens the login page.