### PR TITLE
iss-hipm-999: Make database transaction see its own changes

### DIFF
--- a/Sources/HiPMobile/DataAccessLayer/EFCoreDataAccess.cs
+++ b/Sources/HiPMobile/DataAccessLayer/EFCoreDataAccess.cs
@@ -110,6 +110,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.DataAccessLayer
 
                 if (scope.IsDbContextTransient)
                     scope.Db.SaveChangesAndDetach();
+                else
+                    scope.Db.SaveChanges();
             }
         }
 
@@ -121,6 +123,8 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.DataAccessLayer
 
                 if (scope.IsDbContextTransient)
                     scope.Db.SaveChangesAndDetach();
+                else
+                    scope.Db.SaveChanges();
             }
         }
 

--- a/Sources/HiPMobile/DataAccessLayer/EFCoreTransaction.cs
+++ b/Sources/HiPMobile/DataAccessLayer/EFCoreTransaction.cs
@@ -14,6 +14,7 @@
 
 using Microsoft.EntityFrameworkCore;
 using System;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.DataAccessLayer
 {
@@ -23,6 +24,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.DataAccessLayer
         private readonly AppDatabaseContext db;
 
         private bool rolledBack = false;
+        private IDbContextTransaction transaction;
 
         public override ITransactionDataAccess DataAccess { get; }
 
@@ -32,6 +34,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.DataAccessLayer
         {
             this.db = db ?? throw new ArgumentNullException(nameof(db));
             DataAccess = new EFCoreDataAccess(db);
+            transaction = db.Database.BeginTransaction();
         }
 
         public override void Commit()
@@ -39,12 +42,14 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.DataAccessLayer
             if (rolledBack) return;
 
             db.SaveChangesAndDetach();
+            transaction.Commit();
             db.Dispose();
         }
 
         public override void Rollback()
         {
             rolledBack = true;
+            transaction.Rollback();
             db.Dispose();
         }
     }


### PR DESCRIPTION
In Entity Framework Core, any changes made to the database will become visible even inside a transaction only as soon as `SaveChanges` is called. So far, this method was only called by us at the very end of a transaction, making it unable to see even its own changes. Our own methods for executing changes in a transaction also did not actually use an SQL transaction; it merely postponed writing the changes to the database until all changes were made in-memory without any Exceptions.

This PR changes this behavior by calling `SaveChanges` in every call to `AddItem` and `RemoveItem` (at a slight performance cost). To ensure that changes occurring in the transaction will only be actually applied if and only if the transaction succeeds, an actual SQL transaction is now wrapping the changes. Thus, even though `SaveChanges` is called after every modification, they will still be rolled back when an Exception occurs.

To test this PR, you may paste the following method into the `MainPageViewModel.cs` and call it from its constructor:

```C#
async void Test()
        {
            await DbManager.InTransactionAsync(transaction =>
            {
                var access = transaction.DataAccess;
                var routes = access.GetItems<Route>();
                access.DeleteItem(routes[0]);
                var newRoutes = access.GetItems<Route>();

                if (routes.Count == newRoutes.Count)
                {
                    throw new Exception("");
                }
            });
        }
```

This code will make the app crash in its current state (in `master`). Once switching to the branch `iss-hipm-999`, the crash should disappear, since `newRoutes` will be empty, in contrast to `routes`.

Once this PR is merged, we'll need to take a look at #227 again and see which changes no longer need to be included there.