### PR TITLE
iss-hipm-auth0-changes

### DIFF
--- a/Sources/HiPMobile/ServiceAccessLayer/ServerEndpoints.cs
+++ b/Sources/HiPMobile/ServiceAccessLayer/ServerEndpoints.cs
@@ -16,7 +16,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
 {
     public static class ServerEndpoints
     {
-        private const string BaseUrl = "https://hip.eu.auth0.com/";
+        private const string BaseUrl = "https://hip2.eu.auth0.com/";
 
         public const string LoginUrl = BaseUrl + "oauth/token";
 
@@ -34,6 +34,6 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.Shared.ServiceAccessLayer
 
         public const string ThumbnailApiPath = "https://docker-hip.cs.upb.de/public/thumbnailservice/api/Thumbnails";
         
-        public const string DataStoreTokenUrl = "https://hip.eu.auth0.com/oauth/token";
+        public const string DataStoreTokenUrl = "https://hip2.eu.auth0.com/oauth/token";
     }
 }

--- a/Sources/HipMobileUI/ViewModels/Views/LoginScreenViewModel.cs
+++ b/Sources/HipMobileUI/ViewModels/Views/LoginScreenViewModel.cs
@@ -70,7 +70,7 @@ namespace PaderbornUniversity.SILab.Hip.Mobile.UI.ViewModels.Views
         private void OnDebugLoginClicked()
         {
 #if DEBUG
-            Email = Constants.DebugUsername;
+            Email = Constants.DebugEmail;
             Password = Constants.DebugPassword;
             PerformLogin();
 #else


### PR DESCRIPTION
Updated auth0 connection strings to use second auth0 tenant which is used for the public environment of the services according to Patrick.

I have also updated hip-mobile-internal.